### PR TITLE
Update Java and C++ templates

### DIFF
--- a/vscode-wpilib/resources/gradle/cpp/build.gradle
+++ b/vscode-wpilib/resources/gradle/cpp/build.gradle
@@ -29,7 +29,7 @@ deploy {
             files = fileTree(dir: 'src/main/deploy')
             // Deploy to RoboRIO target, into /home/lvuser/deploy
             targets << "roborio"
-            directory = 'deploy'
+            directory = '/home/lvuser/deploy'
         }
     }
 }
@@ -58,7 +58,7 @@ model {
                 }
             }
 
-            // Defining my dependencies. In this case, WPILib (+ friends)
+            // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
             useLibrary(it, "wpilib")
             useCppVendorLibraries(it)
         }
@@ -82,6 +82,4 @@ model {
 
 wrapper {
     gradleVersion = '4.9'
-    distributionPath = 'permwrappers/dists'
-    archivePath = 'permwrappers/dists'
 }

--- a/vscode-wpilib/resources/gradle/java/build.gradle
+++ b/vscode-wpilib/resources/gradle/java/build.gradle
@@ -29,13 +29,13 @@ deploy {
             files = fileTree(dir: 'src/main/deploy')
             // Deploy to RoboRIO target, into /home/lvuser/deploy
             targets << "roborio"
-            directory = 'deploy'
+            directory = '/home/lvuser/deploy'
         }
     }
 }
 
-// Defining my dependencies. In this case, WPILib (+ friends), CTRE Toolsuite (Talon SRX)
-// and NavX.
+// Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
+// Also defines JUnit 4.
 dependencies {
     compile wpilib()
     compile javaVendorLibraries()
@@ -54,6 +54,4 @@ jar {
 
 wrapper {
     gradleVersion = '4.9'
-    distributionPath = 'permwrappers/dists'
-    archivePath = 'permwrappers/dists'
 }


### PR DESCRIPTION
GradleRIO now handles wrapper location. 
Fully quantify `/home/lvuser/deploy` to make it more obvious to users where the deploy location is.