### PR TITLE
Declare JDK version in build.gradle

### DIFF
--- a/vscode-wpilib/resources/gradle/java/build.gradle
+++ b/vscode-wpilib/resources/gradle/java/build.gradle
@@ -3,6 +3,9 @@ plugins {
     id "edu.wpi.first.GradleRIO" version "###GRADLERIOREPLACE###"
 }
 
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
+
 def ROBOT_MAIN_CLASS = "###ROBOTCLASSREPLACE###"
 
 // Define my targets (RoboRIO) and artifacts (deployable files)


### PR DESCRIPTION
This addition specifies which JDK Gradle should use to compile the project when the user has multiple JDKs installed. This setting also syncs to multiple IDEs if other IDEs than VSCode are being used. It's good practice to declare this in Gradle Java projects.