### PR TITLE
Fix simulation on Linux and macOS

### DIFF
--- a/vscode-wpilib/src/cpp/deploydebug.ts
+++ b/vscode-wpilib/src/cpp/deploydebug.ts
@@ -241,6 +241,7 @@ class SimulateCodeDeployer implements ICodeDeployer {
         clang: targetSimulateInfo.clang!,
         executablePath: targetSimulateInfo.launchfile,
         extensions,
+        ldPath: path.dirname(targetSimulateInfo.launchfile),    // gradle puts all the libs in the same dir as the executable
         soLibPath: soPath,
         srcPaths: new Set<string>(targetSimulateInfo.srcpaths),
         stopAtEntry: this.preferences.getPreferences(workspace).getStopSimulationOnEntry(),

--- a/vscode-wpilib/src/cpp/simulateunix.ts
+++ b/vscode-wpilib/src/cpp/simulateunix.ts
@@ -9,6 +9,7 @@ export interface IUnixSimulateCommands {
   stopAtEntry: boolean;
   clang: boolean;
   soLibPath: string;
+  ldPath: string;
   srcPaths: Set<string>;
 }
 
@@ -17,10 +18,14 @@ export async function startUnixSimulation(commands: IUnixSimulateCommands): Prom
     MIMode: commands.clang ? 'lldb' : 'gdb',
     additionalSOLibSearchPath: commands.soLibPath,
     cwd: commands.workspace.uri.fsPath,
-    environment: {
-      HALSIM_EXTENSIONS: commands.extensions,
-    },
-    externalConsole: true,
+    environment: [{
+      name: 'HALSIM_EXTENSIONS', value: commands.extensions,
+    }, {
+      name: 'LD_LIBRARY_PATH', value: commands.ldPath,
+    }, {
+      name: 'DYLD_FALLBACK_LIBRARY_PATH', value: commands.ldPath,
+    }],
+    externalConsole: false,
     name: 'WPILib C++ Simulate',
     program: commands.executablePath,
     request: 'launch',

--- a/vscode-wpilib/src/java/simulate.ts
+++ b/vscode-wpilib/src/java/simulate.ts
@@ -17,7 +17,9 @@ export async function startSimulation(commands: ISimulateCommands): Promise<void
     console: 'integratedTerminal',
     cwd: commands.workspace.uri.fsPath,
     env: {
+      DYLD_LIBRARY_PATH: commands.librarydir,
       HALSIM_EXTENSIONS: commands.extensions,
+      LD_LIBRARY_PATH: commands.librarydir,
       PATH: commands.librarydir,
     },
     mainClass: commands.mainclass,


### PR DESCRIPTION
- The unix debug configuration had some incorrect properties
- The unix debug configuration needed to properly set `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH` for Linux and macOS respectively, the soLibPath does not work as it should
- The java debug configuration needed to set `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH` in order to find transitive .so dependencies.

Partially requires wpilibsuite/GradleRIO#293 (for multiproject builds)