### PR TITLE
Add helpers if users selected wrong folder.

### DIFF
--- a/vscode-wpilib/package.json
+++ b/vscode-wpilib/package.json
@@ -14,8 +14,8 @@
         "Other"
     ],
     "activationEvents": [
-        "workspaceContains:.wpilib/wpilib_preferences.json",
-        "workspaceContains:build/vscodeconfig.json",
+        "workspaceContains:.wpilib/**/wpilib_preferences.json",
+        "workspaceContains:build/**/vscodeconfig.json",
         "onCommand:wpilibcore.startRioLog",
         "onCommand:wpilibcore.setTeamNumber",
         "onCommand:wpilibcore.startTool",

--- a/vscode-wpilib/src/extension.ts
+++ b/vscode-wpilib/src/extension.ts
@@ -26,7 +26,7 @@ import { promisifyMkdirp } from './shared/generator';
 import { UtilitiesAPI } from './shared/utilitiesapi';
 import { addVendorExamples } from './shared/vendorexamples';
 import { ToolAPI } from './toolapi';
-import { promisifyExists, setExtensionContext, setJavaHome } from './utilities';
+import { setExtensionContext, setJavaHome } from './utilities';
 import { fireVendorDepsChanged, VendorLibraries } from './vendorlibraries';
 import { createVsCommands } from './vscommands';
 import { AlphaError } from './webviews/alphaerror';

--- a/vscode-wpilib/src/preferences.ts
+++ b/vscode-wpilib/src/preferences.ts
@@ -32,6 +32,9 @@ export async function requestTeamNumber(): Promise<number> {
 
 // Stores the preferences for a specific workspace
 export class Preferences implements IPreferences {
+  public static readonly preferenceFileName: string = 'wpilib_preferences.json';
+  public static readonly wpilibPreferencesFolder: string = '.wpilib';
+
   // Create for a specific workspace
   public static async Create(workspace: vscode.WorkspaceFolder): Promise<Preferences> {
     const prefs = new Preferences(workspace);
@@ -39,21 +42,22 @@ export class Preferences implements IPreferences {
     return prefs;
   }
 
+  public static getPrefrencesFilePath(root: string): string {
+    return path.join(root, Preferences.wpilibPreferencesFolder, Preferences.preferenceFileName);
+  }
+
   // Workspace these preferences are assigned to.
   public workspace: vscode.WorkspaceFolder;
 
   private preferencesFile?: vscode.Uri;
-  private readonly configFolder: string;
-  private readonly preferenceFileName: string = 'wpilib_preferences.json';
   private preferencesJson: IPreferencesJson = defaultPreferences;
   private configFileWatcher: vscode.FileSystemWatcher;
-  private readonly preferencesGlob: string = '**/' + this.preferenceFileName;
+  private readonly preferencesGlob: string = '**/' + Preferences.preferenceFileName;
   private disposables: vscode.Disposable[] = [];
   private isWPILibProject: boolean = false;
 
   private constructor(workspace: vscode.WorkspaceFolder) {
     this.workspace = workspace;
-    this.configFolder = path.join(workspace.uri.fsPath, '.wpilib');
 
     const rp = new vscode.RelativePattern(workspace, this.preferencesGlob);
 
@@ -222,7 +226,7 @@ export class Preferences implements IPreferences {
   }
 
   private async asyncInitialize() {
-    const configFilePath = path.join(this.configFolder, this.preferenceFileName);
+    const configFilePath = Preferences.getPrefrencesFilePath(this.workspace.uri.fsPath);
 
     if (await promisifyExists(configFilePath)) {
       vscode.commands.executeCommand('setContext', 'isWPILibProject', true);
@@ -252,7 +256,7 @@ export class Preferences implements IPreferences {
 
   private async writePreferences(): Promise<void> {
     if (this.preferencesFile === undefined) {
-      const configFilePath = path.join(this.configFolder, this.preferenceFileName);
+      const configFilePath = Preferences.getPrefrencesFilePath(this.workspace.uri.fsPath);
       this.preferencesFile = vscode.Uri.file(configFilePath);
       await promisifyMkDir(path.dirname(this.preferencesFile.fsPath));
     }


### PR DESCRIPTION
Many people are opening 1 folder too high. This PR causes that to be detected, and prompt that the right folder might be a subfolder.

If only one subfolder, only give the option to go to that.

If multiple, prompt allowing the user to pick.

Both options have a don't ask again.

Only goes 1 subfolder deep, not multiple.