### PR TITLE
remove required vendordep.json properties which aren't used and aren't required

### DIFF
--- a/vscode-wpilib/resources/vendorschema.json
+++ b/vscode-wpilib/resources/vendorschema.json
@@ -83,7 +83,6 @@
             "groupId",
             "artifactId",
             "version",
-            "skipOnUnknownClassifier",
             "isJar",
             "validClassifiers"
           ]
@@ -142,14 +141,9 @@
             "groupId",
             "artifactId",
             "version",
-            "isHeaderOnly",
             "headerClassifier",
-            "hasSources",
-            "sourcesClassifier",
             "sharedLibrary",
-            "libName",
-            "skipOnUnknownClassifier",
-            "validClassifiers"
+            "libName"
           ]
         }
       ]


### PR DESCRIPTION
vendordeps phoenix.json and navx_frc.json aren't using:
- isHeaderOnly
- hasSources
- skipOnUnknownClassifier
- validClassifiers
- sourcesClassifier

The following patch will prevent the wpilib-vscode extension from identifying these absences as problems. I.e. we can't control 3rd party vendor errors. So please stop polluting our ide with errors which we can't control and have to ignore. 