### PR TITLE
Patch security vulnerability by updating vscode package

### DIFF
--- a/vscode-wpilib/i18n/zh-CN/package.i18n.json
+++ b/vscode-wpilib/i18n/zh-CN/package.i18n.json
@@ -26,6 +26,7 @@
 	"wpilibcore.installGradleTools.title": "从 GradleRIO 安装工具",
 	"wpilibcore.showLogFolder.title": "显示目录文件夹",
 	"wpilibcore.resetAutoUpdate.title": "重制自动检查 WPILib 更新设置",
+	"wpilibcore.runGradleCommand.title": "Run a command in Gradle",
 	"wpilibcore.changeDesktop.title": "设置桌面支持属性",
 	"wpilibcore.setDeployOffline.title": "在离线模式中 更改 部署/调试命令 设置",
 	"wpilibcore.setOffline.title": "在离线模式中 更改 部署/调试命令 外的设置"

--- a/vscode-wpilib/package-lock.json
+++ b/vscode-wpilib/package-lock.json
@@ -4,6 +4,37 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@gulp-sourcemaps/identity-map": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz",
+            "integrity": "sha512-ciiioYMLdo16ShmfHBXJBOFm3xPC4AuwO4xeRpFeHz7WK9PYsWCmigagG2XyzZpubK4a3qNKoUBDhbzHfa50LQ==",
+            "dev": true,
+            "requires": {
+                "acorn": "^5.0.3",
+                "css": "^2.2.1",
+                "normalize-path": "^2.1.1",
+                "source-map": "^0.6.0",
+                "through2": "^2.0.3"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@gulp-sourcemaps/map-sources": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+            "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
+            "dev": true,
+            "requires": {
+                "normalize-path": "^2.0.1",
+                "through2": "^2.0.3"
+            }
+        },
         "@justinc/dir-exists": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@justinc/dir-exists/-/dir-exists-2.1.0.tgz",
@@ -1333,6 +1364,15 @@
             "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
         "copy-concurrently": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -1467,6 +1507,26 @@
                 "randomfill": "^1.0.3"
             }
         },
+        "css": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+            "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "source-map": "^0.6.1",
+                "source-map-resolve": "^0.5.2",
+                "urix": "^0.1.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
         "css-select": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -1528,6 +1588,34 @@
             "dev": true,
             "requires": {
                 "ms": "2.0.0"
+            }
+        },
+        "debug-fabulous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.1.0.tgz",
+            "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
+            "dev": true,
+            "requires": {
+                "debug": "3.X",
+                "memoizee": "0.4.X",
+                "object-assign": "4.X"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
             }
         },
         "decamelize": {
@@ -1664,6 +1752,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
             "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+            "dev": true
+        },
+        "detect-newline": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
             "dev": true
         },
         "diagnostics": {
@@ -1965,6 +2059,16 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
+        },
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
+            }
         },
         "event-stream": {
             "version": "3.3.4",
@@ -3240,6 +3344,33 @@
                 "vinyl": "^2.0.1"
             }
         },
+        "gulp-sourcemaps": {
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.4.tgz",
+            "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
+            "dev": true,
+            "requires": {
+                "@gulp-sourcemaps/identity-map": "1.X",
+                "@gulp-sourcemaps/map-sources": "1.X",
+                "acorn": "5.X",
+                "convert-source-map": "1.X",
+                "css": "2.X",
+                "debug-fabulous": "1.X",
+                "detect-newline": "2.X",
+                "graceful-fs": "4.X",
+                "source-map": "~0.6.0",
+                "strip-bom-string": "1.X",
+                "through2": "2.X"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
         "gulp-typescript": {
             "version": "5.0.0-alpha.3",
             "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-5.0.0-alpha.3.tgz",
@@ -3958,6 +4089,12 @@
                 "isobject": "^3.0.1"
             }
         },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
+        },
         "is-relative": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
@@ -4405,6 +4542,15 @@
                 "yallist": "^2.1.2"
             }
         },
+        "lru-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+            "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+            "dev": true,
+            "requires": {
+                "es5-ext": "~0.10.2"
+            }
+        },
         "make-dir": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -4508,6 +4654,22 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^1.0.0"
+            }
+        },
+        "memoizee": {
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+            "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.45",
+                "es6-weak-map": "^2.0.2",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.1",
+                "lru-queue": "0.1",
+                "next-tick": "1",
+                "timers-ext": "^0.1.5"
             }
         },
         "memory-fs": {
@@ -6441,6 +6603,12 @@
                 "is-utf8": "^0.2.0"
             }
         },
+        "strip-bom-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+            "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
+            "dev": true
+        },
         "strip-eof": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -6524,6 +6692,16 @@
             "dev": true,
             "requires": {
                 "setimmediate": "^1.0.4"
+            }
+        },
+        "timers-ext": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+            "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "~0.10.46",
+                "next-tick": "1"
             }
         },
         "tmp": {

--- a/vscode-wpilib/package-lock.json
+++ b/vscode-wpilib/package-lock.json
@@ -74,9 +74,9 @@
             }
         },
         "@types/node": {
-            "version": "8.10.29",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.29.tgz",
-            "integrity": "sha512-zbteaWZ2mdduacm0byELwtRyhYE40aK+pAanQk415gr1eRuu67x7QGOLmn8jz5zI8LDK7d0WI/oT6r5Trz4rzQ==",
+            "version": "8.10.39",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.39.tgz",
+            "integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA==",
             "dev": true
         },
         "@types/node-fetch": {
@@ -304,15 +304,15 @@
             }
         },
         "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "version": "6.8.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
+            "integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
             "dev": true,
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
+                "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
         },
         "ajv-keywords": {
@@ -780,7 +780,6 @@
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
@@ -1192,12 +1191,6 @@
                 "readable-stream": "^2.3.5"
             }
         },
-        "co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true
-        },
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1282,9 +1275,9 @@
             }
         },
         "combined-stream": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "dev": true,
             "requires": {
                 "delayed-stream": "~1.0.0"
@@ -1338,12 +1331,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
             "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-            "dev": true
-        },
-        "convert-source-map": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-            "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
             "dev": true
         },
         "copy-concurrently": {
@@ -1809,7 +1796,6 @@
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -2061,57 +2047,6 @@
                 }
             }
         },
-        "expand-range": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true,
-            "requires": {
-                "fill-range": "^2.1.0"
-            },
-            "dependencies": {
-                "fill-range": {
-                    "version": "2.2.4",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-                    "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-                    "dev": true,
-                    "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^3.0.0",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
-                    }
-                },
-                "is-number": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    }
-                },
-                "isobject": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                    "dev": true,
-                    "requires": {
-                        "isarray": "1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
-        },
         "expand-tilde": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -2231,9 +2166,9 @@
             }
         },
         "fast-deep-equal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
             "dev": true
         },
         "fast-json-stable-stringify": {
@@ -2260,12 +2195,6 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
             "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
-        },
-        "filename-regex": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-            "dev": true
         },
         "fill-range": {
             "version": "4.0.0",
@@ -2347,12 +2276,6 @@
                 "parse-filepath": "^1.0.1"
             }
         },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
         "flagged-respawn": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
@@ -2391,13 +2314,13 @@
             "dev": true
         },
         "form-data": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "dev": true,
             "requires": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "1.0.6",
+                "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
             }
         },
@@ -3040,42 +2963,6 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true,
-            "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^2.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                }
-            }
-        },
         "glob-parent": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -3341,316 +3228,16 @@
             }
         },
         "gulp-remote-src-vscode": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.0.tgz",
-            "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.1.tgz",
+            "integrity": "sha512-mw4OGjtC/jlCWJFhbcAlel4YPvccChlpsl3JceNiB/DLJi24/UPxXt53/N26lgI3dknEqd4ErfdHrO8sJ5bATQ==",
             "dev": true,
             "requires": {
-                "event-stream": "^3.3.4",
+                "event-stream": "3.3.4",
                 "node.extend": "^1.1.2",
                 "request": "^2.79.0",
                 "through2": "^2.0.3",
                 "vinyl": "^2.0.1"
-            }
-        },
-        "gulp-sourcemaps": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-            "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-            "dev": true,
-            "requires": {
-                "convert-source-map": "^1.1.1",
-                "graceful-fs": "^4.1.2",
-                "strip-bom": "^2.0.0",
-                "through2": "^2.0.0",
-                "vinyl": "^1.0.0"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-                    "dev": true
-                },
-                "clone-stats": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-                    "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
-            }
-        },
-        "gulp-symdest": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
-            "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
-            "dev": true,
-            "requires": {
-                "event-stream": "^3.3.1",
-                "mkdirp": "^0.5.1",
-                "queue": "^3.1.0",
-                "vinyl-fs": "^2.4.3"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.0.1"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-                    "dev": true
-                },
-                "clone-stats": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-                    "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-                    "dev": true
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "5.0.15",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true,
-                    "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "glob-stream": {
-                    "version": "5.3.5",
-                    "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-                    "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-                    "dev": true,
-                    "requires": {
-                        "extend": "^3.0.0",
-                        "glob": "^5.0.3",
-                        "glob-parent": "^3.0.0",
-                        "micromatch": "^2.3.7",
-                        "ordered-read-streams": "^0.3.0",
-                        "through2": "^0.6.0",
-                        "to-absolute-glob": "^0.1.1",
-                        "unique-stream": "^2.0.2"
-                    },
-                    "dependencies": {
-                        "readable-stream": {
-                            "version": "1.0.34",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                            "dev": true,
-                            "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.1",
-                                "isarray": "0.0.1",
-                                "string_decoder": "~0.10.x"
-                            }
-                        },
-                        "through2": {
-                            "version": "0.6.5",
-                            "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                            "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                            "dev": true,
-                            "requires": {
-                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                                "xtend": ">=4.0.0 <4.1.0-0"
-                            }
-                        }
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "is-valid-glob": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-                    "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
-                    }
-                },
-                "ordered-read-streams": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-                    "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-                    "dev": true,
-                    "requires": {
-                        "is-stream": "^1.0.1",
-                        "readable-stream": "^2.0.1"
-                    }
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-                    "dev": true
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "to-absolute-glob": {
-                    "version": "0.1.1",
-                    "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-                    "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1"
-                    }
-                },
-                "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                },
-                "vinyl-fs": {
-                    "version": "2.4.4",
-                    "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-                    "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-                    "dev": true,
-                    "requires": {
-                        "duplexify": "^3.2.0",
-                        "glob-stream": "^5.3.2",
-                        "graceful-fs": "^4.0.0",
-                        "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "^0.3.0",
-                        "lazystream": "^1.0.0",
-                        "lodash.isequal": "^4.0.0",
-                        "merge-stream": "^1.0.0",
-                        "mkdirp": "^0.5.0",
-                        "object-assign": "^4.0.0",
-                        "readable-stream": "^2.0.4",
-                        "strip-bom": "^2.0.0",
-                        "strip-bom-stream": "^1.0.0",
-                        "through2": "^2.0.0",
-                        "through2-filter": "^2.0.0",
-                        "vali-date": "^1.0.0",
-                        "vinyl": "^1.0.0"
-                    }
-                }
             }
         },
         "gulp-typescript": {
@@ -3818,273 +3405,18 @@
             }
         },
         "gulp-vinyl-zip": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
-            "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.2.tgz",
+            "integrity": "sha512-wJn09jsb8PyvUeyFF7y7ImEJqJwYy40BqL9GKfJs6UGpaGW9A+N68Q+ajsIpb9AeR6lAdjMbIdDPclIGo1/b7Q==",
             "dev": true,
             "requires": {
-                "event-stream": "^3.3.1",
+                "event-stream": "3.3.4",
                 "queue": "^4.2.1",
                 "through2": "^2.0.3",
                 "vinyl": "^2.0.2",
-                "vinyl-fs": "^2.0.0",
+                "vinyl-fs": "^3.0.3",
                 "yauzl": "^2.2.1",
                 "yazl": "^2.2.1"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.0.1"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-                    "dev": true
-                },
-                "clone-stats": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-                    "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-                    "dev": true
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "5.0.15",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true,
-                    "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "glob-stream": {
-                    "version": "5.3.5",
-                    "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-                    "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-                    "dev": true,
-                    "requires": {
-                        "extend": "^3.0.0",
-                        "glob": "^5.0.3",
-                        "glob-parent": "^3.0.0",
-                        "micromatch": "^2.3.7",
-                        "ordered-read-streams": "^0.3.0",
-                        "through2": "^0.6.0",
-                        "to-absolute-glob": "^0.1.1",
-                        "unique-stream": "^2.0.2"
-                    },
-                    "dependencies": {
-                        "readable-stream": {
-                            "version": "1.0.34",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                            "dev": true,
-                            "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.1",
-                                "isarray": "0.0.1",
-                                "string_decoder": "~0.10.x"
-                            }
-                        },
-                        "through2": {
-                            "version": "0.6.5",
-                            "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                            "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                            "dev": true,
-                            "requires": {
-                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                                "xtend": ">=4.0.0 <4.1.0-0"
-                            }
-                        }
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "is-valid-glob": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-                    "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
-                    }
-                },
-                "ordered-read-streams": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-                    "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-                    "dev": true,
-                    "requires": {
-                        "is-stream": "^1.0.1",
-                        "readable-stream": "^2.0.1"
-                    }
-                },
-                "queue": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.0.tgz",
-                    "integrity": "sha512-DwxpAnqJuoQa+wyDgQuwkSshkhlqIlWEvwvdAY27fDPunZ2cVJzXU4JyjY+5l7zs7oGLaYAQm4MbLOVFAHFBzA==",
-                    "dev": true,
-                    "requires": {
-                        "inherits": "~2.0.0"
-                    }
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-                    "dev": true
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "to-absolute-glob": {
-                    "version": "0.1.1",
-                    "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-                    "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1"
-                    }
-                },
-                "vinyl-fs": {
-                    "version": "2.4.4",
-                    "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-                    "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-                    "dev": true,
-                    "requires": {
-                        "duplexify": "^3.2.0",
-                        "glob-stream": "^5.3.2",
-                        "graceful-fs": "^4.0.0",
-                        "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "^0.3.0",
-                        "lazystream": "^1.0.0",
-                        "lodash.isequal": "^4.0.0",
-                        "merge-stream": "^1.0.0",
-                        "mkdirp": "^0.5.0",
-                        "object-assign": "^4.0.0",
-                        "readable-stream": "^2.0.4",
-                        "strip-bom": "^2.0.0",
-                        "strip-bom-stream": "^1.0.0",
-                        "through2": "^2.0.0",
-                        "through2-filter": "^2.0.0",
-                        "vali-date": "^1.0.0",
-                        "vinyl": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "vinyl": {
-                            "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                            "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                            "dev": true,
-                            "requires": {
-                                "clone": "^1.0.0",
-                                "clone-stats": "^0.0.1",
-                                "replace-ext": "0.0.1"
-                            }
-                        }
-                    }
-                }
             }
         },
         "gulplog": {
@@ -4103,13 +3435,22 @@
             "dev": true
         },
         "har-validator": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-            "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "dev": true,
             "requires": {
-                "ajv": "^5.3.0",
+                "ajv": "^6.5.5",
                 "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
@@ -4522,21 +3863,6 @@
                 }
             }
         },
-        "is-dotfile": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-            "dev": true
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
-            "requires": {
-                "is-primitive": "^2.0.0"
-            }
-        },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4631,18 +3957,6 @@
             "requires": {
                 "isobject": "^3.0.1"
             }
-        },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
         },
         "is-relative": {
             "version": "1.0.0",
@@ -4739,8 +4053,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "json-parse-better-errors": {
             "version": "1.0.2",
@@ -4755,9 +4068,9 @@
             "dev": true
         },
         "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
         "json-stringify-safe": {
@@ -5019,12 +4332,6 @@
             "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
             "dev": true
         },
-        "lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-            "dev": true
-        },
         "lodash.keys": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -5177,12 +4484,6 @@
                 "stack-trace": "0.0.10"
             }
         },
-        "math-random": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-            "dev": true
-        },
         "md5.js": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -5216,15 +4517,6 @@
             "dev": true,
             "requires": {
                 "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
-            }
-        },
-        "merge-stream": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "dev": true,
-            "requires": {
                 "readable-stream": "^2.0.1"
             }
         },
@@ -5266,18 +4558,18 @@
             "dev": true
         },
         "mime-db": {
-            "version": "1.36.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-            "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+            "version": "1.37.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.20",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-            "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+            "version": "2.1.21",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.36.0"
+                "mime-db": "~1.37.0"
             }
         },
         "mimic-fn": {
@@ -5591,12 +4883,13 @@
             }
         },
         "node.extend": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
-            "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
+            "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
             "dev": true,
             "requires": {
-                "is": "^3.1.0"
+                "has": "^1.0.3",
+                "is": "^3.2.1"
             }
         },
         "normalize-package-data": {
@@ -5743,27 +5036,6 @@
             "requires": {
                 "for-own": "^1.0.0",
                 "make-iterator": "^1.0.0"
-            }
-        },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true,
-            "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
-            },
-            "dependencies": {
-                "for-own": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-                    "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-                    "dev": true,
-                    "requires": {
-                        "for-in": "^1.0.1"
-                    }
-                }
             }
         },
         "object.pick": {
@@ -5931,35 +5203,6 @@
                 "is-absolute": "^1.0.0",
                 "map-cache": "^0.2.0",
                 "path-root": "^0.1.1"
-            }
-        },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
-            "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                }
             }
         },
         "parse-json": {
@@ -6212,12 +5455,6 @@
             "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
             "dev": true
         },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-            "dev": true
-        },
         "pretty-hrtime": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -6263,9 +5500,9 @@
             "dev": true
         },
         "psl": {
-            "version": "1.1.29",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+            "version": "1.1.31",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+            "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
             "dev": true
         },
         "public-encrypt": {
@@ -6334,37 +5571,18 @@
             "dev": true
         },
         "querystringify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
-            "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+            "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
             "dev": true
         },
         "queue": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
-            "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
+            "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
             "dev": true,
             "requires": {
                 "inherits": "~2.0.0"
-            }
-        },
-        "randomatic": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-            "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
-            "dev": true,
-            "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-                    "dev": true
-                }
             }
         },
         "randombytes": {
@@ -6449,15 +5667,6 @@
             "dev": true,
             "requires": {
                 "resolve": "^1.1.6"
-            }
-        },
-        "regex-cache": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "dev": true,
-            "requires": {
-                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -7069,9 +6278,9 @@
             "dev": true
         },
         "sshpk": {
-            "version": "1.14.2",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-            "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "dev": true,
             "requires": {
                 "asn1": "~0.2.3",
@@ -7230,16 +6439,6 @@
             "dev": true,
             "requires": {
                 "is-utf8": "^0.2.0"
-            }
-        },
-        "strip-bom-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-            "dev": true,
-            "requires": {
-                "first-chunk-stream": "^1.0.0",
-                "strip-bom": "^2.0.0"
             }
         },
         "strip-eof": {
@@ -7577,8 +6776,7 @@
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "typed-rest-client": {
             "version": "0.9.0",
@@ -7867,9 +7065,9 @@
             "dev": true
         },
         "url-parse": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
-            "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+            "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
             "dev": true,
             "requires": {
                 "querystringify": "^2.0.0",
@@ -7916,12 +7114,6 @@
             "requires": {
                 "homedir-polyfill": "^1.0.1"
             }
-        },
-        "vali-date": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-            "dev": true
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
@@ -8081,24 +7273,24 @@
             }
         },
         "vscode": {
-            "version": "1.1.21",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.21.tgz",
-            "integrity": "sha512-tJl9eL15ZMm6vzCYYeQ26sSYRuXGMGPsaeIAmG2rOOYRn01jdaDg6I4b9G5Ed6FISdmn6egpKThk4o4om8Ax/A==",
+            "version": "1.1.29",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.29.tgz",
+            "integrity": "sha512-E6hzqGtCD65BnBxdZzSIi8FPCM4seEEK/bbTeYdJntg+4D5R6GLbdYFySE9DNTtMJF4iB9UGoucKU/p8Guts1g==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.2",
                 "gulp-chmod": "^2.0.0",
                 "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "^0.5.0",
-                "gulp-symdest": "^1.1.0",
+                "gulp-remote-src-vscode": "^0.5.1",
                 "gulp-untar": "^0.0.7",
-                "gulp-vinyl-zip": "^2.1.0",
+                "gulp-vinyl-zip": "^2.1.2",
                 "mocha": "^4.0.1",
-                "request": "^2.83.0",
+                "request": "^2.88.0",
                 "semver": "^5.4.1",
                 "source-map-support": "^0.5.0",
                 "url-parse": "^1.4.3",
+                "vinyl-fs": "^3.0.3",
                 "vinyl-source-stream": "^1.1.0"
             },
             "dependencies": {

--- a/vscode-wpilib/package.json
+++ b/vscode-wpilib/package.json
@@ -410,7 +410,7 @@
         "tslint": "^5.11.0",
         "typescript": "^3.0.1",
         "vsce": "^1.53.0",
-        "vscode": "^1.1.21",
+        "vscode": "^1.1.29",
         "vscode-nls-dev": "^3.2.3",
         "webpack": "^4.25.1",
         "webpack-cli": "^3.1.2"

--- a/vscode-wpilib/package.json
+++ b/vscode-wpilib/package.json
@@ -402,6 +402,7 @@
         "gulp-filter": "^5.1.0",
         "gulp-json-transform": "^0.4.5",
         "gulp-typescript": "^5.0.0-alpha.3",
+        "gulp-sourcemaps": "^2.6.4",
         "mocha": "^5.2.0",
         "rmdir-cli": "^2.0.6",
         "run-sequence": "^2.2.1",


### PR DESCRIPTION
Doesn't change version compatibility.

This PR also tests with vscode 1.31, because of the electron update. Things still compile, so no use of deprecated functions