### PR TITLE
Use compileClasspath in generated build.gradle files

### DIFF
--- a/vscode-wpilib/resources/gradle/java/build.gradle
+++ b/vscode-wpilib/resources/gradle/java/build.gradle
@@ -59,6 +59,6 @@ dependencies {
 // in order to make them all available at runtime. Also adding the manifest so WPILib
 // knows where to look for our Robot Class.
 jar {
-    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     manifest edu.wpi.first.gradlerio.GradleRIOPlugin.javaManifest(ROBOT_MAIN_CLASS)
 }

--- a/vscode-wpilib/resources/gradle/javadt/build.gradle
+++ b/vscode-wpilib/resources/gradle/javadt/build.gradle
@@ -21,6 +21,6 @@ dependencies {
 // in order to make them all available at runtime. Also adding the manifest so WPILib
 // knows where to look for our Robot Class.
 jar {
-    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     manifest edu.wpi.first.gradlerio.GradleRIOPlugin.javaManifest(ROBOT_MAIN_CLASS)
 }


### PR DESCRIPTION
The previous `configurations.compile.collect` only collected dependencies marked with `compile`. `configurations.compileClasspath.collect` collects dependencies with both `compile` and `implementation`, making it strictly better.