### PR TITLE
Add support for disabling specifc binary types, and multiple language versions

### DIFF
--- a/vscode-wpilib/i18n/zh-CN/package.i18n.json
+++ b/vscode-wpilib/i18n/zh-CN/package.i18n.json
@@ -29,5 +29,6 @@
 	"wpilibcore.runGradleCommand.title": "Run a command in Gradle",
 	"wpilibcore.changeDesktop.title": "设置桌面支持属性",
 	"wpilibcore.setDeployOffline.title": "在离线模式中 更改 部署/调试命令 设置",
-	"wpilibcore.setOffline.title": "在离线模式中 更改 部署/调试命令 外的设置"
+	"wpilibcore.setOffline.title": "在离线模式中 更改 部署/调试命令 外的设置",
+	"wpilibcore.selectCppBinaryTypes.title": "Select Enabled C++ Intellisense Binary Types"
 }

--- a/vscode-wpilib/package.json
+++ b/vscode-wpilib/package.json
@@ -251,6 +251,11 @@
                 "category": "WPILib C++"
             },
             {
+                "command": "wpilibcore.selectCppBinaryTypes",
+                "title": "%wpilibcore.selectCppBinaryTypes.title%",
+                "category": "WPILib C++"
+            },
+            {
                 "command": "wpilibcore.importEclipseProject",
                 "title": "%wpilibcore.importEclipseProject.title%",
                 "category": "WPILib"

--- a/vscode-wpilib/package.nls.json
+++ b/vscode-wpilib/package.nls.json
@@ -29,5 +29,6 @@
 	"wpilibcore.showLogFolder.title": "Show Log Folder",
 	"wpilibcore.runGradleCommand.title": "Run a command in Gradle",
 	"wpilibcore.resetAutoUpdate.title": "Reset Ask for WPILib Updates Flag",
-	"wpilibcore.changeDesktop.title": "Change Desktop Support Enabled Setting"
+	"wpilibcore.changeDesktop.title": "Change Desktop Support Enabled Setting",
+	"wpilibcore.selectCppBinaryTypes.title": "Select Enabled C++ Intellisense Binary Types"
 }

--- a/vscode-wpilib/src/cppprovider/headertreeprovider.ts
+++ b/vscode-wpilib/src/cppprovider/headertreeprovider.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { logger } from '../logger';
 import { IToolChain } from './jsonformats';
+import { IEnabledBuildTypes } from './apiprovider';
 
 //#region Utilities
 
@@ -109,6 +110,7 @@ interface Entry {
 export class HeaderTreeProvider implements vscode.TreeDataProvider<Entry> {
 
   private toolchains: IToolChain | undefined;
+  private enabledBuildTypes: IEnabledBuildTypes | undefined;
 
   private _onDidChangeFile: vscode.EventEmitter<Entry | undefined | null>;
 
@@ -123,8 +125,9 @@ export class HeaderTreeProvider implements vscode.TreeDataProvider<Entry> {
     return this._onDidChangeFile.event;
   }
 
-  public updateToolChains(toolchains: IToolChain) {
+  public updateToolChains(toolchains: IToolChain, enables: IEnabledBuildTypes) {
     this.toolchains = toolchains;
+    this.enabledBuildTypes = enables;
     this._onDidChangeFile.fire(undefined);
   }
 
@@ -199,8 +202,33 @@ export class HeaderTreeProvider implements vscode.TreeDataProvider<Entry> {
       return entries;
     }
 
+    const currentBinaryTypes = this.enabledBuildTypes;
+
     for (const bin of this.toolchains.binaries) {
-      entries.push({binaryFiles: bin.libHeaders, binaryName: bin.componentName, type: vscode.FileType.Unknown,
+      if (currentBinaryTypes !== undefined) {
+        if (bin.executable === true && currentBinaryTypes.executables === false) {
+          continue;
+        }
+
+        if (bin.sharedLibrary === true && currentBinaryTypes.sharedLibraries === false) {
+          continue;
+        }
+
+        if (bin.executable === false && bin.sharedLibrary === false && currentBinaryTypes.staticLibraries === false) {
+          continue;
+        }
+      }
+
+      let exeType = '';
+      if (bin.executable === true) {
+        exeType = ' (Exe)';
+      } else if (bin.sharedLibrary === true) {
+        exeType = ' (Shared)';
+      } else if (bin.sharedLibrary !== undefined && bin.executable !== undefined) {
+        exeType = ' (Static)';
+      }
+
+      entries.push({binaryFiles: bin.libHeaders, binaryName: bin.componentName + ` ${exeType}`, type: vscode.FileType.Unknown,
                     uri: vscode.Uri.file(bin.componentName)});
     }
 
@@ -245,8 +273,8 @@ export class HeaderExplorer {
     vscode.commands.registerCommand('fileExplorer.openFile', (resource: vscode.Uri) => this.openResource(resource));
   }
 
-  public updateToolChains(toolchains: IToolChain) {
-    this.treeDataProvider.updateToolChains(toolchains);
+  public updateToolChains(toolchains: IToolChain, enables: IEnabledBuildTypes) {
+    this.treeDataProvider.updateToolChains(toolchains, enables);
   }
 
   public dispose() {

--- a/vscode-wpilib/src/cppprovider/headertreeprovider.ts
+++ b/vscode-wpilib/src/cppprovider/headertreeprovider.ts
@@ -4,8 +4,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { logger } from '../logger';
-import { IToolChain } from './jsonformats';
 import { IEnabledBuildTypes } from './apiprovider';
+import { IToolChain } from './jsonformats';
 
 //#region Utilities
 

--- a/vscode-wpilib/src/cppprovider/jsonformats.ts
+++ b/vscode-wpilib/src/cppprovider/jsonformats.ts
@@ -6,6 +6,10 @@ export interface ISourceBinaryPair {
   cpp: boolean;
   args: string[];
   macros: string[];
+  sharedLibrary?: boolean;
+  executable?: boolean;
+  langVersion?: 'c89' | 'c99' | 'c11' | 'c++98' | 'c++03' | 'c++11' | 'c++14' | 'c++17';
+  langVersionSet?: boolean;
 }
 
 export interface ISource {
@@ -26,6 +30,8 @@ export interface IBinary {
   componentName: string;
   sourceSets: ISourceSet[];
   libHeaders: string[];
+  sharedLibrary?: boolean;
+  executable?: boolean;
 }
 
 export interface IBinaryMap {
@@ -42,6 +48,7 @@ export interface IToolChain {
   cppPath: string;
   cPath: string;
   msvc: boolean;
+  gcc?: boolean;
   systemCppMacros: string[];
   systemCppArgs: string[];
   systemCMacros: string[];
@@ -50,4 +57,6 @@ export interface IToolChain {
   binaries: IBinary[];
   sourceBinaries: ISourceBinaryPair[];
   nameBinaryMap: { [name: string]: number };
+  cppLangVersion?: 'c89' | 'c99' | 'c11' | 'c++98' | 'c++03' | 'c++11' | 'c++14' | 'c++17';
+  cLangVersion?: 'c89' | 'c99' | 'c11' | 'c++98' | 'c++03' | 'c++11' | 'c++14' | 'c++17';
 }

--- a/vscode-wpilib/src/cppprovider/vscommands.ts
+++ b/vscode-wpilib/src/cppprovider/vscommands.ts
@@ -18,6 +18,22 @@ export function createCommands(context: vscode.ExtensionContext, configLoaders: 
     }
   }));
 
+  context.subscriptions.push(vscode.commands.registerCommand('wpilibcore.selectCppBinaryTypes', async () => {
+    const workspaces = vscode.workspace.workspaceFolders;
+
+    if (workspaces === undefined) {
+      return;
+    }
+
+    for (const wp of workspaces) {
+      for (const loader of configLoaders) {
+        if (wp.uri.fsPath === loader.workspace.uri.fsPath) {
+          await loader.selectEnabledBinaryTypes();
+        }
+      }
+    }
+  }));
+
   // The command has been defined in the package.json file
   // Now provide the implementation of the command with  registerCommand
   // The commandId parameter must match the command field in package.json


### PR DESCRIPTION
Useful if the same library is built shared and static, and we want to detect intellisense on one or the other

Closes #250 
Closes #251 