### PR TITLE
Fix project import errors

### DIFF
--- a/vscode-wpilib/src/shared/generator.ts
+++ b/vscode-wpilib/src/shared/generator.ts
@@ -10,154 +10,63 @@ type CopyCallback = (srcFolder: string, rootFolder: string) => Promise<boolean>;
 
 export async function generateCopyCpp(resourcesFolder: string, fromTemplateFolder: string | CopyCallback, fromGradleFolder: string, toFolder: string,
                                       addCpp: boolean, directGradleImport: boolean, oldCommands: boolean): Promise<boolean> {
-  const existingFiles = await readdirAsync(toFolder);
-  if (existingFiles.length > 0) {
-    logger.warn('folder not empty');
-    return false;
-  }
+  try {
+    const existingFiles = await readdirAsync(toFolder);
+    if (existingFiles.length > 0) {
+      logger.warn('folder not empty');
+      return false;
+    }
 
-  let codePath = path.join(toFolder, 'src', 'main');
-  if (addCpp) {
-    codePath = path.join(codePath, 'cpp');
-  } else if (directGradleImport) {
-    codePath = path.join(toFolder, 'src');
-  }
+    let codePath = path.join(toFolder, 'src', 'main');
+    if (addCpp) {
+      codePath = path.join(codePath, 'cpp');
+    } else if (directGradleImport) {
+      codePath = path.join(toFolder, 'src');
+    }
 
-  const gradleRioFrom = '###GRADLERIOREPLACE###';
+    const gradleRioFrom = '###GRADLERIOREPLACE###';
 
-  const grRoot = path.dirname(fromGradleFolder);
+    const grRoot = path.dirname(fromGradleFolder);
 
-  const grVersionFile = path.join(grRoot, 'version.txt');
+    const grVersionFile = path.join(grRoot, 'version.txt');
 
-  const grVersionTo = (await readFileAsync(grVersionFile, 'utf8')).trim();
+    const grVersionTo = (await readFileAsync(grVersionFile, 'utf8')).trim();
 
-  if (typeof fromTemplateFolder === 'string') {
-    await ncpAsync(fromTemplateFolder, codePath);
-  } else {
-    await fromTemplateFolder(codePath, toFolder);
-  }
-  await ncpAsync(fromGradleFolder, toFolder, {
-    filter: (cf): boolean => {
-      const rooted = path.relative(fromGradleFolder, cf);
-      if (rooted.startsWith('bin') || rooted.indexOf('.project') >= 0) {
-        return false;
-      }
-      return true;
-    },
-  });
-  await ncpAsync(path.join(grRoot, 'shared'), toFolder, {
-    filter: (cf): boolean => {
-      const rooted = path.relative(fromGradleFolder, cf);
-      if (rooted.startsWith('bin') || rooted.indexOf('.project') >= 0) {
-        return false;
-      }
-      return true;
-    },
-  });
-
-  await setExecutePermissions(path.join(toFolder, 'gradlew'));
-
-  const buildgradle = path.join(toFolder, 'build.gradle');
-
-  await new Promise<void>((resolve, reject) => {
-    fs.readFile(buildgradle, 'utf8', (err, dataIn) => {
-      if (err) {
-        resolve();
-      } else {
-        const dataOut = dataIn.replace(new RegExp(gradleRioFrom, 'g'), grVersionTo);
-        fs.writeFile(buildgradle, dataOut, 'utf8', (err1) => {
-          if (err1) {
-            reject(err);
-          } else {
-            resolve();
-          }
-        });
-      }
+    if (typeof fromTemplateFolder === 'string') {
+      await ncpAsync(fromTemplateFolder, codePath);
+    } else {
+      await fromTemplateFolder(codePath, toFolder);
+    }
+    await ncpAsync(fromGradleFolder, toFolder, {
+      filter: (cf): boolean => {
+        const rooted = path.relative(fromGradleFolder, cf);
+        if (rooted.startsWith('bin') || rooted.indexOf('.project') >= 0) {
+          return false;
+        }
+        return true;
+      },
     });
-  });
-
-  if (!directGradleImport) {
-    const deployDir = path.join(toFolder, 'src', 'main', 'deploy');
-
-    await mkdirpAsync(deployDir);
-
-    await writeFileAsync(path.join(deployDir, 'example.txt'), i18n('generator', [ 'generateCppDeployHint',
-  `Files placed in this directory will be deployed to the RoboRIO into the
-  'deploy' directory in the home folder. Use the 'frc::filesystem::GetDeployDirectory'
-  function from the 'frc/Filesystem.h' header to get a proper path relative to the deploy
-  directory.` ]));
-  }
-
-  const vendorDir = path.join(toFolder, 'vendordeps');
-  await mkdirpAsync(vendorDir);
-  const commandName = oldCommands ? 'WPILibOldCommands.json' : 'WPILibNewCommands.json';
-  const vendorFile = path.join(path.dirname(resourcesFolder), 'vendordeps', commandName);
-  await copyFileAsync(vendorFile, path.join(vendorDir, commandName));
-
-  return true;
-}
-
-export async function generateCopyJava(resourcesFolder: string, fromTemplateFolder: string | CopyCallback, fromGradleFolder: string, toFolder: string,
-                                       robotClassTo: string, copyRoot: string, directGradleImport: boolean, oldCommands: boolean,
-                                       packageReplaceString?: string | undefined): Promise<boolean> {
-  const existingFiles = await readdirAsync(toFolder);
-  if (existingFiles.length > 0) {
-    return false;
-  }
-
-  const rootCodePath = path.join(toFolder, 'src', 'main', 'java');
-  let codePath = path.join(rootCodePath, copyRoot);
-  if (directGradleImport) {
-    codePath = path.join(toFolder, 'src');
-  }
-
-  if (typeof fromTemplateFolder === 'string') {
-    await ncpAsync(fromTemplateFolder, codePath);
-  } else {
-    await fromTemplateFolder(codePath, toFolder);
-  }
-
-  const files = await new Promise<string[]>((resolve, reject) => {
-    glob('**/*', {
-      cwd: codePath,
-      nodir: true,
-      nomount: true,
-    }, (err, matches) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(matches);
-      }
+    await ncpAsync(path.join(grRoot, 'shared'), toFolder, {
+      filter: (cf): boolean => {
+        const rooted = path.relative(fromGradleFolder, cf);
+        if (rooted.startsWith('bin') || rooted.indexOf('.project') >= 0) {
+          return false;
+        }
+        return true;
+      },
     });
-  });
-  // Package replace inside the template
 
-  const replacePackageFrom = 'edu\\.wpi\\.first\\.wpilibj\\.(?:examples|templates)\\..+?(?=;|\\.)';
-  const replacePackageTo = 'frc.robot';
+    await setExecutePermissions(path.join(toFolder, 'gradlew'));
 
-  const robotClassFrom = '###ROBOTCLASSREPLACE###';
-  const gradleRioFrom = '###GRADLERIOREPLACE###';
+    const buildgradle = path.join(toFolder, 'build.gradle');
 
-  const grRoot = path.dirname(fromGradleFolder);
-
-  const grVersionFile = path.join(grRoot, 'version.txt');
-
-  const grVersionTo = (await readFileAsync(grVersionFile, 'utf8')).trim();
-
-  const promiseArray: Array<Promise<void>> = [];
-
-  for (const f of files) {
-    const file = path.join(codePath, f);
-    promiseArray.push(new Promise<void>((resolve, reject) => {
-      fs.readFile(file, 'utf8', (err, dataIn) => {
+    await new Promise<void>((resolve, reject) => {
+      fs.readFile(buildgradle, 'utf8', (err, dataIn) => {
         if (err) {
-          reject(err);
+          resolve();
         } else {
-          let dataOut = dataIn.replace(new RegExp(replacePackageFrom, 'g'), replacePackageTo);
-          if (packageReplaceString !== undefined) {
-            dataOut = dataOut.replace(new RegExp(packageReplaceString, 'g'), replacePackageTo);
-          }
-          fs.writeFile(file, dataOut, 'utf8', (err1) => {
+          const dataOut = dataIn.replace(new RegExp(gradleRioFrom, 'g'), grVersionTo);
+          fs.writeFile(buildgradle, dataOut, 'utf8', (err1) => {
             if (err1) {
               reject(err);
             } else {
@@ -166,68 +75,169 @@ export async function generateCopyJava(resourcesFolder: string, fromTemplateFold
           });
         }
       });
-    }));
+    });
+
+    if (!directGradleImport) {
+      const deployDir = path.join(toFolder, 'src', 'main', 'deploy');
+
+      await mkdirpAsync(deployDir);
+
+      await writeFileAsync(path.join(deployDir, 'example.txt'), i18n('generator', ['generateCppDeployHint',
+        `Files placed in this directory will be deployed to the RoboRIO into the
+  'deploy' directory in the home folder. Use the 'frc::filesystem::GetDeployDirectory'
+  function from the 'frc/Filesystem.h' header to get a proper path relative to the deploy
+  directory.` ]));
+    }
+
+    const vendorDir = path.join(toFolder, 'vendordeps');
+    await mkdirpAsync(vendorDir);
+    const commandName = oldCommands ? 'WPILibOldCommands.json' : 'WPILibNewCommands.json';
+    const vendorFile = path.join(path.dirname(resourcesFolder), 'vendordeps', commandName);
+    await copyFileAsync(vendorFile, path.join(vendorDir, commandName));
+
+    return true;
+  } catch (e) {
+    logger.error('Project creation failure', e);
+    return false;
   }
+}
 
-  await ncpAsync(fromGradleFolder, toFolder, {
-    filter: (cf): boolean => {
-      const rooted = path.relative(fromGradleFolder, cf);
-      if (rooted.startsWith('bin') || rooted.indexOf('.project') >= 0) {
-        return false;
-      }
-      return true;
-    },
-  });
-  await ncpAsync(path.join(grRoot, 'shared'), toFolder, {
-    filter: (cf): boolean => {
-      const rooted = path.relative(fromGradleFolder, cf);
-      if (rooted.startsWith('bin') || rooted.indexOf('.project') >= 0) {
-        return false;
-      }
-      return true;
-    },
-  });
+export async function generateCopyJava(resourcesFolder: string, fromTemplateFolder: string | CopyCallback, fromGradleFolder: string, toFolder: string,
+                                       robotClassTo: string, copyRoot: string, directGradleImport: boolean, oldCommands: boolean,
+                                       packageReplaceString?: string | undefined): Promise<boolean> {
+  try {
+    const existingFiles = await readdirAsync(toFolder);
+    if (existingFiles.length > 0) {
+      return false;
+    }
 
-  await setExecutePermissions(path.join(toFolder, 'gradlew'));
+    const rootCodePath = path.join(toFolder, 'src', 'main', 'java');
+    let codePath = path.join(rootCodePath, copyRoot);
+    if (directGradleImport) {
+      codePath = path.join(toFolder, 'src');
+    }
 
-  const buildgradle = path.join(toFolder, 'build.gradle');
+    if (typeof fromTemplateFolder === 'string') {
+      await ncpAsync(fromTemplateFolder, codePath);
+    } else {
+      await fromTemplateFolder(codePath, toFolder);
+    }
 
-  await new Promise<void>((resolve, reject) => {
-    fs.readFile(buildgradle, 'utf8', (err, dataIn) => {
-      if (err) {
-        resolve();
-      } else {
-        const dataOut = dataIn.replace(new RegExp(robotClassFrom, 'g'), robotClassTo)
-                              .replace(new RegExp(gradleRioFrom, 'g'), grVersionTo);
-        fs.writeFile(buildgradle, dataOut, 'utf8', (err1) => {
-          if (err1) {
+    const files = await new Promise<string[]>((resolve, reject) => {
+      glob('**/*', {
+        cwd: codePath,
+        nodir: true,
+        nomount: true,
+      }, (err, matches) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(matches);
+        }
+      });
+    });
+    // Package replace inside the template
+
+    const replacePackageFrom = 'edu\\.wpi\\.first\\.wpilibj\\.(?:examples|templates)\\..+?(?=;|\\.)';
+    const replacePackageTo = 'frc.robot';
+
+    const robotClassFrom = '###ROBOTCLASSREPLACE###';
+    const gradleRioFrom = '###GRADLERIOREPLACE###';
+
+    const grRoot = path.dirname(fromGradleFolder);
+
+    const grVersionFile = path.join(grRoot, 'version.txt');
+
+    const grVersionTo = (await readFileAsync(grVersionFile, 'utf8')).trim();
+
+    const promiseArray: Array<Promise<void>> = [];
+
+    for (const f of files) {
+      const file = path.join(codePath, f);
+      promiseArray.push(new Promise<void>((resolve, reject) => {
+        fs.readFile(file, 'utf8', (err, dataIn) => {
+          if (err) {
             reject(err);
           } else {
-            resolve();
+            let dataOut = dataIn.replace(new RegExp(replacePackageFrom, 'g'), replacePackageTo);
+            if (packageReplaceString !== undefined) {
+              dataOut = dataOut.replace(new RegExp(packageReplaceString, 'g'), replacePackageTo);
+            }
+            fs.writeFile(file, dataOut, 'utf8', (err1) => {
+              if (err1) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
           }
         });
-      }
+      }));
+    }
+
+    await ncpAsync(fromGradleFolder, toFolder, {
+      filter: (cf): boolean => {
+        const rooted = path.relative(fromGradleFolder, cf);
+        if (rooted.startsWith('bin') || rooted.indexOf('.project') >= 0) {
+          return false;
+        }
+        return true;
+      },
     });
-  });
+    await ncpAsync(path.join(grRoot, 'shared'), toFolder, {
+      filter: (cf): boolean => {
+        const rooted = path.relative(fromGradleFolder, cf);
+        if (rooted.startsWith('bin') || rooted.indexOf('.project') >= 0) {
+          return false;
+        }
+        return true;
+      },
+    });
 
-  if (!directGradleImport) {
-    const deployDir = path.join(toFolder, 'src', 'main', 'deploy');
+    await setExecutePermissions(path.join(toFolder, 'gradlew'));
 
-    await mkdirpAsync(deployDir);
+    const buildgradle = path.join(toFolder, 'build.gradle');
 
-    await writeFileAsync(path.join(deployDir, 'example.txt'), i18n('generator', [ 'generateJavaDeployHint',
-`Files placed in this directory will be deployed to the RoboRIO into the
+    await new Promise<void>((resolve, reject) => {
+      fs.readFile(buildgradle, 'utf8', (err, dataIn) => {
+        if (err) {
+          resolve();
+        } else {
+          const dataOut = dataIn.replace(new RegExp(robotClassFrom, 'g'), robotClassTo)
+            .replace(new RegExp(gradleRioFrom, 'g'), grVersionTo);
+          fs.writeFile(buildgradle, dataOut, 'utf8', (err1) => {
+            if (err1) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          });
+        }
+      });
+    });
+
+    if (!directGradleImport) {
+      const deployDir = path.join(toFolder, 'src', 'main', 'deploy');
+
+      await mkdirpAsync(deployDir);
+
+      await writeFileAsync(path.join(deployDir, 'example.txt'), i18n('generator', ['generateJavaDeployHint',
+        `Files placed in this directory will be deployed to the RoboRIO into the
 'deploy' directory in the home folder. Use the 'Filesystem.getDeployDirectory' wpilib function
 to get a proper path relative to the deploy directory.` ]));
+    }
+
+    const vendorDir = path.join(toFolder, 'vendordeps');
+    await mkdirpAsync(vendorDir);
+    const commandName = oldCommands ? 'WPILibOldCommands.json' : 'WPILibNewCommands.json';
+    const vendorFile = path.join(path.dirname(resourcesFolder), 'vendordeps', commandName);
+    await copyFileAsync(vendorFile, path.join(vendorDir, commandName));
+
+    return true;
+  } catch (e) {
+    logger.error('Project creation failure', e);
+    return false;
   }
-
-  const vendorDir = path.join(toFolder, 'vendordeps');
-  await mkdirpAsync(vendorDir);
-  const commandName = oldCommands ? 'WPILibOldCommands.json' : 'WPILibNewCommands.json';
-  const vendorFile = path.join(path.dirname(resourcesFolder), 'vendordeps', commandName);
-  await copyFileAsync(vendorFile, path.join(vendorDir, commandName));
-
-  return true;
 }
 
 export function setDesktopEnabled(buildgradle: string, setting: boolean): Promise<void> {
@@ -237,7 +247,7 @@ export function setDesktopEnabled(buildgradle: string, setting: boolean): Promis
         resolve();
       } else {
         const dataOut = dataIn.replace(/def\s+includeDesktopSupport\s*=\s*(true|false)/gm,
-                                       `def includeDesktopSupport = ${setting ? 'true' : 'false'}`);
+          `def includeDesktopSupport = ${setting ? 'true' : 'false'}`);
         fs.writeFile(buildgradle, dataOut, 'utf8', (err1) => {
           if (err1) {
             reject(err);

--- a/vscode-wpilib/src/utilities.ts
+++ b/vscode-wpilib/src/utilities.ts
@@ -126,7 +126,8 @@ export function getDesktopEnabled(buildgradle: string): Promise<boolean | undefi
 }
 
 export async function promptForProjectOpen(toFolder: vscode.Uri): Promise<boolean> {
-  const openSelection = await vscode.window.showInformationMessage(i18n('message', 'Would you like to open the folder?'), {
+  const openSelection = await vscode.window.showInformationMessage(i18n('message',
+      'Project successfully created. Would you like to open the folder?'), {
     modal: true,
   }, i18n('ui', 'Yes (Current Window)'), i18n('ui', 'Yes (New Window)'), i18n('ui', 'No'));
   if (openSelection === undefined) {

--- a/vscode-wpilib/src/webviews/eclipseimport.ts
+++ b/vscode-wpilib/src/webviews/eclipseimport.ts
@@ -147,10 +147,10 @@ export class EclipseImport extends WebViewBase {
     let success = false;
     if (cpp) {
       const gradlePath = path.join(gradleBasePath, 'cpp');
-      success = await generateCopyCpp(resourceRoot, path.join(oldProjectPath, 'src'), gradlePath, toFolder, true, false, true);
+      success = await generateCopyCpp(path.join(resourceRoot, 'cpp'), path.join(oldProjectPath, 'src'), gradlePath, toFolder, true, false, true);
     } else {
       const gradlePath = path.join(gradleBasePath, 'java');
-      success = await generateCopyJava(resourceRoot, path.join(oldProjectPath, 'src'), gradlePath, toFolder, javaRobotPackage + '.Main', '', false,
+      success = await generateCopyJava(path.join(resourceRoot, 'java'), path.join(oldProjectPath, 'src'), gradlePath, toFolder, javaRobotPackage + '.Main', '', false,
                                        true);
     }
 

--- a/vscode-wpilib/src/webviews/gradle2019import.ts
+++ b/vscode-wpilib/src/webviews/gradle2019import.ts
@@ -216,10 +216,11 @@ export class Gradle2019Import extends WebViewBase {
     let success = false;
     if (cpp) {
       const gradlePath = path.join(gradleBasePath, 'cpp');
-      success = await generateCopyCpp(resourceRoot, path.join(oldProjectPath, 'src'), gradlePath, toFolder, false, true, true);
+      success = await generateCopyCpp(path.join(resourceRoot, 'cpp'), path.join(oldProjectPath, 'src'), gradlePath, toFolder, false, true, true);
     } else {
       const gradlePath = path.join(gradleBasePath, 'java');
-      success = await generateCopyJava(resourceRoot, path.join(oldProjectPath, 'src'), gradlePath, toFolder, javaRobotPackage, '', true, true);
+      success = await generateCopyJava(path.join(resourceRoot, 'java'), path.join(oldProjectPath, 'src'), gradlePath, toFolder,
+                                       javaRobotPackage, '', true, true);
     }
 
     if (!success) {


### PR DESCRIPTION
They were using the wrong resource root.

The error was being silently ignored, since these are fired from the Webview and not vscode. So added a giant try catch to make sure it gets caught, logged, and a message shown