### PR TITLE
Add setting for selecting a default extension.

### DIFF
--- a/vscode-wpilib/locale/zh-cn/package.i18n.yaml
+++ b/vscode-wpilib/locale/zh-cn/package.i18n.yaml
@@ -9,6 +9,7 @@ wpilibcore.simulateCode.title: 在电脑上模拟运行机器人代码
 wpilibcore.setLanguage.title: 设置语言
 wpilibcore.setAutoSave.title: 设置部署时自动保存
 wpilibcore.setSkipTests.title: 设置是否跳过测试API
+wpilibcore.selectDefaultSimulateExtension.title: Set to select the simulation extension automatically, if there is only one
 wpilibcore.setStopSimulationOnEntry.title: 设置是否在进入时停止模拟运行
 wpilibcore.setStartRioLog.title: 设置是否在部署时启动 RioLog
 wpilibcore.createCommand.title: 创建一个新的类/命令

--- a/vscode-wpilib/package.json
+++ b/vscode-wpilib/package.json
@@ -27,6 +27,7 @@
         "onCommand:wpilibcore.setLanguage",
         "onCommand:wpilibcore.setAutoSave",
         "onCommand:wpilibcore.setSkipTests",
+        "onCommand:wpilibcore.setSelectDefaultSimulateExtension",
         "onCommand:wpilibcore.setOffline",
         "onCommand:wpilibcore.setStopSimulationOnEntry",
         "onCommand:wpilibcore.setStartRioLog",
@@ -130,6 +131,12 @@
                     "description": "Set to skip running tests on build",
                     "scope": "resource"
                 },
+                "wpilib.selectDefaultSimulateExtension": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "Set to select the simulation extension automatically, if there is only one",
+                    "scope": "resource"
+                },
                 "wpilib.stopSimulationOnEntry": {
                     "type": "boolean",
                     "default": "false",
@@ -194,6 +201,11 @@
             {
                 "command": "wpilibcore.setSkipTests",
                 "title": "%wpilibcore.setSkipTests.title%",
+                "category": "WPILib"
+            },
+            {
+                "command": "wpilibcore.setSelectDefaultSimulateExtension",
+                "title": "%wpilibcore.setSelectDefaultSimulateExtension.title%",
                 "category": "WPILib"
             },
             {

--- a/vscode-wpilib/package.nls.json
+++ b/vscode-wpilib/package.nls.json
@@ -10,6 +10,7 @@
 	"wpilibcore.setLanguage.title": "Change Language Setting",
 	"wpilibcore.setAutoSave.title": "Change Auto Save On Deploy Setting",
 	"wpilibcore.setSkipTests.title": "Change Skip Tests On Deploy Setting",
+	"wpilibcore.setSelectDefaultSimulateExtension.title": "Change Select Default Simulate Extension Setting",
 	"wpilibcore.setOffline.title": "Change Run Commands Except Deploy/Debug in Offline Mode Setting",
 	"wpilibcore.setDeployOffline.title": "Change Run Deploy/Debug Command in Offline Mode Setting",
 	"wpilibcore.setStopSimulationOnEntry.title": "Change Stop Simulation on Entry Setting",

--- a/vscode-wpilib/src/java/deploydebug.ts
+++ b/vscode-wpilib/src/java/deploydebug.ts
@@ -203,14 +203,19 @@ class SimulateCodeDeployer implements ICodeDeployer {
           path: e,
         });
       }
-      const quickPick = await vscode.window.showQuickPick(extList, {
-        canPickMany: true,
-        placeHolder: 'Pick extensions to run',
-      });
-      if (quickPick !== undefined) {
-        for (const qp of quickPick) {
-          extensions += qp.path;
-          extensions += path.delimiter;
+      if (this.preferences.getPreferences(workspace).getSelectDefaultSimulateExtension() && extList.length === 1) {
+        extensions += extList[0].path;
+        extensions += path.delimiter;
+      } else {
+        const quickPick = await vscode.window.showQuickPick(extList, {
+          canPickMany: true,
+          placeHolder: 'Pick extensions to run',
+        });
+        if (quickPick !== undefined) {
+          for (const qp of quickPick) {
+            extensions += qp.path;
+            extensions += path.delimiter;
+          }
         }
       }
     }

--- a/vscode-wpilib/src/preferences.ts
+++ b/vscode-wpilib/src/preferences.ts
@@ -172,6 +172,14 @@ export class Preferences implements IPreferences {
     return this.getConfiguration().update('skipTests', value, target);
   }
 
+  public async setSelectDefaultSimulateExtension(value: boolean, global: boolean): Promise<void> {
+    let target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global;
+    if (!global) {
+      target = vscode.ConfigurationTarget.WorkspaceFolder;
+    }
+    return this.getConfiguration().update('selectDefaultSimulateExtension', value, target);
+  }
+
   public getAutoSaveOnDeploy(): boolean {
     const res = this.getConfiguration().get<boolean>('autoSaveOnDeploy');
     if (res === undefined) {
@@ -206,6 +214,14 @@ export class Preferences implements IPreferences {
 
   public getSkipTests(): boolean {
     const res = this.getConfiguration().get<boolean>('skipTests');
+    if (res === undefined) {
+      return false;
+    }
+    return res;
+  }
+
+  public getSelectDefaultSimulateExtension(): boolean {
+    const res = this.getConfiguration().get<boolean>('selectDefaultSimulateExtension');
     if (res === undefined) {
       return false;
     }

--- a/vscode-wpilib/src/vscommands.ts
+++ b/vscode-wpilib/src/vscommands.ts
@@ -196,6 +196,27 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
     await preferences.setSkipTests(result.yes, result.global);
   }));
 
+  context.subscriptions.push(vscode.commands.registerCommand('wpilibcore.setSelectDefaultSimulateExtension', async () => {
+    const preferencesApi = externalApi.getPreferencesAPI();
+    const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
+    if (workspace === undefined) {
+      vscode.window.showInformationMessage(i18n('message',
+        'Cannot set select default simulate extension in an empty workspace'));
+      return;
+    }
+
+    const preferences = preferencesApi.getPreferences(workspace);
+
+    const result = await globalProjectSettingUpdate(i18n('message',
+      'Enable selecting of default simulate extension? Currently {0}', preferences.getSelectDefaultSimulateExtension()));
+    if (result === undefined) {
+      logger.log('Invalid selection for selecting default simulate extension');
+      return;
+    }
+
+    await preferences.setSelectDefaultSimulateExtension(result.yes, result.global);
+  }));
+
   context.subscriptions.push(vscode.commands.registerCommand('wpilibcore.setOffline', async () => {
     const preferencesApi = externalApi.getPreferencesAPI();
     const workspace = await preferencesApi.getFirstOrSelectedWorkspace();


### PR DESCRIPTION
When running the *Simulate Robot Code on desktop* command, there is a quick pick dialog prompting for a simulation extension to choose:
![image](https://user-images.githubusercontent.com/13039555/74598940-b901ed00-5048-11ea-9020-a10a2ffb3580.png)
As far as I have tested this feature, this extension is the only one that there is to choose from. The [documentation](https://docs.wpilib.org/en/latest/docs/software/wpilib-tools/robot-simulation/simulation-gui.html) seems to confirm that, at least for most people's purposes, this is the only option:
> And the `halsim_gui.dll` option should popup in a new dialog. Select this and press Ok.

When repeatedly testing changes, this gets repetitive and tedious, continually selecting this DLL and clicking Ok.

This pull request adds a setting that allows this extension to bypass this menu if there is only one to choose from. I have not made this the default behavior, because I don't entirely understand what the implications of doing so would be, in terms of what other kinds of extensions you could possibly use.