### PR TITLE
Enable driverstation sim extension by default

### DIFF
--- a/vscode-wpilib/resources/gradle/cpp/build.gradle
+++ b/vscode-wpilib/resources/gradle/cpp/build.gradle
@@ -47,6 +47,11 @@ def includeDesktopSupport = false
 // upon debugging
 dependencies {
     simulation wpi.deps.sim.gui(wpi.platforms.desktop, true)
+    simulation wpi.deps.sim.driverstation(wpi.platforms.desktop, true)
+
+    // Websocket extensions require additional configuration.
+    // simulation wpi.deps.sim.ws_server(wpi.platforms.desktop, true)
+    // simulation wpi.deps.sim.ws_client(wpi.platforms.desktop, true)
 }
 
 model {

--- a/vscode-wpilib/resources/gradle/java/build.gradle
+++ b/vscode-wpilib/resources/gradle/java/build.gradle
@@ -57,6 +57,11 @@ dependencies {
     // Enable simulation gui support. Must check the box in vscode to enable support
     // upon debugging
     simulation wpi.deps.sim.gui(wpi.platforms.desktop, false)
+    simulation wpi.deps.sim.driverstation(wpi.platforms.desktop, false)
+
+    // Websocket extensions require additional configuration.
+    // simulation wpi.deps.sim.ws_server(wpi.platforms.desktop, false)
+    // simulation wpi.deps.sim.ws_client(wpi.platforms.desktop, false)
 }
 
 // Setting up my Jar File. In this case, adding all libraries into the main jar ('fat jar')


### PR DESCRIPTION
Also add commented-out lines for ws_server and ws_client extensions;
these require additional environment variable settings so don't enable
them by default until we document them.