### PR TITLE
Add beta teams only note to auto-release

### DIFF
--- a/.github/ReleaseBody.txt
+++ b/.github/ReleaseBody.txt
@@ -1,0 +1,3 @@
+# For Beta Teams Only
+
+This release is for beta teams only. Please download the latest stable release (v2020.3.2) if you are not a beta team. You can find v2020.3.2 at https://github.com/wpilibsuite/vscode-wpilib/releases/tag/v2020.3.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,12 +159,16 @@ jobs:
     needs: [build-mac, build-linux, build-windows, build-windows-vsix]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         name: Download Artifacts
+        with:
+          path: artifacts
       - uses: softprops/action-gh-release@v1
         name: Release
         with:
+          body_path: ${{ github.workspace }}/.github/ReleaseBody.txt
           prerelease: true
-          files: "**/*"
+          files: "artifacts/**/*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Example release here: https://github.com/prateekma/vscode-wpilib/releases/tag/v2021.1.1-alpha-3