### PR TITLE
Fix link order for vendordeps

### DIFF
--- a/vscode-wpilib/resources/gradle/cpp/build.gradle
+++ b/vscode-wpilib/resources/gradle/cpp/build.gradle
@@ -76,8 +76,8 @@ model {
             }
 
             // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
-            wpi.deps.wpilib(it)
             wpi.deps.vendor.cpp(it)
+            wpi.deps.wpilib(it)
         }
     }
     testSuites {
@@ -91,9 +91,9 @@ model {
                 }
             }
 
+            wpi.deps.vendor.cpp(it)
             wpi.deps.wpilib(it)
             wpi.deps.googleTest(it)
-            wpi.deps.vendor.cpp(it)
         }
     }
 }


### PR DESCRIPTION
They were being added after wpilib, which means if the robot program
doesn't use wpiutil, REV will fail to find the raw_ostream symbol.