### PR TITLE
Support multiple extensions with "select default simulate extension"

### DIFF
--- a/vscode-wpilib/src/cpp/deploydebug.ts
+++ b/vscode-wpilib/src/cpp/deploydebug.ts
@@ -236,9 +236,11 @@ class SimulateCodeDeployer implements ICodeDeployer {
           path: e,
         });
       }
-      if (this.preferences.getPreferences(workspace).getSelectDefaultSimulateExtension() && extList.length === 1) {
-        extensions += extList[0].path;
-        extensions += path.delimiter;
+      if (this.preferences.getPreferences(workspace).getSelectDefaultSimulateExtension() && extList.length >= 1) {
+        for (const e of extList) {
+          extensions += e.path;
+          extensions += path.delimiter;
+        }
       } else {
         const quickPick = await vscode.window.showQuickPick(extList, {
           canPickMany: true,

--- a/vscode-wpilib/src/cpp/deploydebug.ts
+++ b/vscode-wpilib/src/cpp/deploydebug.ts
@@ -229,28 +229,23 @@ class SimulateCodeDeployer implements ICodeDeployer {
 
     let extensions = '';
     if (targetSimulateInfo.extensions.length > 0) {
+      const pickedByDefault = this.preferences.getPreferences(workspace).getSelectDefaultSimulateExtension();
       const extList = [];
       for (const e of targetSimulateInfo.extensions) {
         extList.push({
           label: path.basename(e),
           path: e,
+          picked: pickedByDefault,
         });
       }
-      if (this.preferences.getPreferences(workspace).getSelectDefaultSimulateExtension() && extList.length >= 1) {
-        for (const e of extList) {
-          extensions += e.path;
+      const quickPick = await vscode.window.showQuickPick(extList, {
+        canPickMany: true,
+        placeHolder: 'Pick extensions to run',
+      });
+      if (quickPick !== undefined) {
+        for (const qp of quickPick) {
+          extensions += qp.path;
           extensions += path.delimiter;
-        }
-      } else {
-        const quickPick = await vscode.window.showQuickPick(extList, {
-          canPickMany: true,
-          placeHolder: 'Pick extensions to run',
-        });
-        if (quickPick !== undefined) {
-          for (const qp of quickPick) {
-            extensions += qp.path;
-            extensions += path.delimiter;
-          }
         }
       }
     }

--- a/vscode-wpilib/src/java/deploydebug.ts
+++ b/vscode-wpilib/src/java/deploydebug.ts
@@ -215,9 +215,11 @@ class SimulateCodeDeployer implements ICodeDeployer {
           path: e,
         });
       }
-      if (this.preferences.getPreferences(workspace).getSelectDefaultSimulateExtension() && extList.length === 1) {
-        extensions += extList[0].path;
-        extensions += path.delimiter;
+      if (this.preferences.getPreferences(workspace).getSelectDefaultSimulateExtension() && extList.length >= 1) {
+        for (const e of extList) {
+          extensions += e.path;
+          extensions += path.delimiter;
+        }
       } else {
         const quickPick = await vscode.window.showQuickPick(extList, {
           canPickMany: true,

--- a/vscode-wpilib/src/java/deploydebug.ts
+++ b/vscode-wpilib/src/java/deploydebug.ts
@@ -208,28 +208,23 @@ class SimulateCodeDeployer implements ICodeDeployer {
 
     let extensions = '';
     if (targetSimulateInfo.extensions.length > 0) {
+      const pickedByDefault = this.preferences.getPreferences(workspace).getSelectDefaultSimulateExtension();
       const extList = [];
       for (const e of targetSimulateInfo.extensions) {
         extList.push({
           label: path.basename(e),
           path: e,
+          picked: pickedByDefault,
         });
       }
-      if (this.preferences.getPreferences(workspace).getSelectDefaultSimulateExtension() && extList.length >= 1) {
-        for (const e of extList) {
-          extensions += e.path;
+      const quickPick = await vscode.window.showQuickPick(extList, {
+        canPickMany: true,
+        placeHolder: 'Pick extensions to run',
+      });
+      if (quickPick !== undefined) {
+        for (const qp of quickPick) {
+          extensions += qp.path;
           extensions += path.delimiter;
-        }
-      } else {
-        const quickPick = await vscode.window.showQuickPick(extList, {
-          canPickMany: true,
-          placeHolder: 'Pick extensions to run',
-        });
-        if (quickPick !== undefined) {
-          for (const qp of quickPick) {
-            extensions += qp.path;
-            extensions += path.delimiter;
-          }
         }
       }
     }


### PR DESCRIPTION
Fixes #408 (enable "select default simulate extension" and it will load all extensions in the project).