### PR TITLE
Enable users to add env vars in gradle for simulation

### DIFF
--- a/vscode-wpilib/src/cpp/deploydebug.ts
+++ b/vscode-wpilib/src/cpp/deploydebug.ts
@@ -21,6 +21,7 @@ interface ICppDebugCommand {
   launchfile: string;
   target: string;
   gdb: string;
+  env?: Map<string, string>;
   sysroot: string | null;
   srcpaths: string[];
   headerpaths: string[];
@@ -264,6 +265,7 @@ class SimulateCodeDeployer implements ICodeDeployer {
       const config: IUnixSimulateCommands = {
         // tslint:disable-next-line:no-non-null-assertion
         clang: targetSimulateInfo.clang!,
+        environment: targetSimulateInfo.env,
         executablePath: targetSimulateInfo.launchfile,
         extensions,
         ldPath: path.dirname(targetSimulateInfo.launchfile),    // gradle puts all the libs in the same dir as the executable
@@ -277,6 +279,7 @@ class SimulateCodeDeployer implements ICodeDeployer {
     } else {
       const config: IWindowsSimulateCommands = {
         debugPaths: targetSimulateInfo.debugpaths,
+        environment: targetSimulateInfo.env,
         extensions,
         launchfile: targetSimulateInfo.launchfile,
         srcPaths: targetSimulateInfo.srcpaths,

--- a/vscode-wpilib/src/cpp/simulateunix.ts
+++ b/vscode-wpilib/src/cpp/simulateunix.ts
@@ -6,6 +6,7 @@ export interface IUnixSimulateCommands {
   executablePath: string;
   extensions: string;
   workspace: vscode.WorkspaceFolder;
+  environment?: Map<string, string>;
   stopAtEntry: boolean;
   clang: boolean;
   soLibPath: string;
@@ -45,6 +46,16 @@ export async function startUnixSimulation(commands: IUnixSimulateCommands): Prom
     config.setupCommands.push({
       text: 'dir ' + a,
     });
+  }
+
+  if (commands.environment !== undefined) {
+    for (const envVar of commands.environment) {
+      /* tslint:disable-next-line:no-unsafe-any */
+      config.enviroment.push({
+        name: envVar[0],
+        value: envVar[1]
+      });
+    }
   }
 
   logger.log('C++ Unix Simulation: ', config);

--- a/vscode-wpilib/src/cpp/simulateunix.ts
+++ b/vscode-wpilib/src/cpp/simulateunix.ts
@@ -6,12 +6,17 @@ export interface IUnixSimulateCommands {
   executablePath: string;
   extensions: string;
   workspace: vscode.WorkspaceFolder;
-  environment?: Map<string, string>;
+  environment?: IEnvMap;
   stopAtEntry: boolean;
   clang: boolean;
   soLibPath: string;
   ldPath: string;
   srcPaths: Set<string>;
+}
+
+interface IEnvMap {
+  // tslint:disable-next-line: no-any
+  [key: string]: any;
 }
 
 export async function startUnixSimulation(commands: IUnixSimulateCommands): Promise<void> {
@@ -49,11 +54,12 @@ export async function startUnixSimulation(commands: IUnixSimulateCommands): Prom
   }
 
   if (commands.environment !== undefined) {
-    for (const envVar of commands.environment) {
+    for (const envVar of Object.keys(commands.environment)) {
+      const value = commands.environment[envVar];
       /* tslint:disable-next-line:no-unsafe-any */
-      config.enviroment.push({
-        name: envVar[0],
-        value: envVar[1]
+      config.environment.push({
+        name: envVar,
+        value,
       });
     }
   }

--- a/vscode-wpilib/src/cpp/simulatewindows.ts
+++ b/vscode-wpilib/src/cpp/simulatewindows.ts
@@ -6,6 +6,7 @@ import { logger } from '../logger';
 
 export interface IWindowsSimulateCommands {
   extensions: string;
+  environment?: Map<string, string>;
   launchfile: string;
   stopAtEntry: boolean;
   workspace: vscode.WorkspaceFolder;
@@ -39,6 +40,16 @@ export async function startWindowsSimulation(commands: IWindowsSimulateCommands)
     symbolSearchPath,
     type: 'cppvsdbg',
   };
+
+  if (commands.environment !== undefined) {
+    for (const envVar of commands.environment) {
+      /* tslint:disable-next-line:no-unsafe-any */
+      config.enviroment.push({
+        name: envVar[0],
+        value: envVar[1]
+      });
+    }
+  }
 
   logger.log('C++ Windows Simulation: ', config);
 

--- a/vscode-wpilib/src/cpp/simulatewindows.ts
+++ b/vscode-wpilib/src/cpp/simulatewindows.ts
@@ -6,12 +6,17 @@ import { logger } from '../logger';
 
 export interface IWindowsSimulateCommands {
   extensions: string;
-  environment?: Map<string, string>;
+  environment?: IEnvMap;
   launchfile: string;
   stopAtEntry: boolean;
   workspace: vscode.WorkspaceFolder;
   debugPaths: string[];
   srcPaths: string[];
+}
+
+interface IEnvMap {
+  // tslint:disable-next-line: no-any
+  [key: string]: any;
 }
 
 export async function startWindowsSimulation(commands: IWindowsSimulateCommands): Promise<void> {
@@ -42,11 +47,12 @@ export async function startWindowsSimulation(commands: IWindowsSimulateCommands)
   };
 
   if (commands.environment !== undefined) {
-    for (const envVar of commands.environment) {
+    for (const envVar of Object.keys(commands.environment)) {
+      const value = commands.environment[envVar];
       /* tslint:disable-next-line:no-unsafe-any */
-      config.enviroment.push({
-        name: envVar[0],
-        value: envVar[1]
+      config.environment.push({
+        name: envVar,
+        value,
       });
     }
   }

--- a/vscode-wpilib/src/java/deploydebug.ts
+++ b/vscode-wpilib/src/java/deploydebug.ts
@@ -21,6 +21,7 @@ interface ITargetInfo {
 
 interface IJavaSimulateInfo {
   name: string;
+  env?: Map<string, string>;
   extensions: string[];
   librarydir: string;
   mainclass: string;
@@ -230,6 +231,7 @@ class SimulateCodeDeployer implements ICodeDeployer {
     }
 
     const config: ISimulateCommands = {
+      environment: targetSimulateInfo.env,
       extensions,
       librarydir: targetSimulateInfo.librarydir,
       mainclass: targetSimulateInfo.mainclass,

--- a/vscode-wpilib/src/java/simulate.ts
+++ b/vscode-wpilib/src/java/simulate.ts
@@ -5,6 +5,7 @@ import { getIsMac, getIsWindows } from '../utilities';
 
 export interface ISimulateCommands {
   extensions: string;
+  environment?: Map<string, string>;
   librarydir: string;
   mainclass: string;
   robotclass: string;

--- a/vscode-wpilib/src/java/simulate.ts
+++ b/vscode-wpilib/src/java/simulate.ts
@@ -5,7 +5,7 @@ import { getIsMac, getIsWindows } from '../utilities';
 
 export interface ISimulateCommands {
   extensions: string;
-  environment?: Map<string, string>;
+  environment?: IEnvMap;
   librarydir: string;
   mainclass: string;
   robotclass: string;
@@ -27,6 +27,13 @@ export async function startSimulation(commands: ISimulateCommands): Promise<void
   } else {
     env.DYLD_LIBRARY_PATH = commands.librarydir;
     env.LD_LIBRARY_PATH = commands.librarydir;
+  }
+
+  if (commands.environment !== undefined) {
+    for (const envVar of Object.keys(commands.environment)) {
+      const value = commands.environment[envVar];
+      env[envVar] = value;
+    }
   }
 
   const config = {


### PR DESCRIPTION
Doesn't fail if theyre missing, so doesn't require newer gradlerio, but requires it for the actual functionality to work.