### PR TITLE
Only enable deploy keybinding within WPILib projects

### DIFF
--- a/vscode-wpilib/package.json
+++ b/vscode-wpilib/package.json
@@ -352,7 +352,8 @@
         "keybindings": [
             {
                 "command": "wpilibcore.deployCode",
-                "key": "shift+F5"
+                "key": "shift+F5",
+                "when": "isWPILibProject"
             }
         ],
         "menus": {


### PR DESCRIPTION
This PR adds a ['when' clause](https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts) to make it so that the `Shift`+`F5` shortcut to deploy the code is only in effect when working in a WPILib Project.