### PR TITLE
Use vscode styles

### DIFF
--- a/vscode-wpilib/src/riolog/shared/sharedscript.ts
+++ b/vscode-wpilib/src/riolog/shared/sharedscript.ts
@@ -2,6 +2,7 @@
 
 /* tslint:disable:prefer-conditional-expression */
 import { IErrorMessage, IIPCSendMessage, IPrintMessage, MessageType, ReceiveTypes, SendTypes } from 'wpilib-riolog';
+import applyVsCodeStyling from '../../webviews/vscodestyling';
 import { checkResize, scrollImpl, sendMessage } from '../script/implscript';
 
 let paused = false;
@@ -569,57 +570,7 @@ function setLivePage() {
     onAutoReconnect();
   }
 
-  const styling = document.createElement('style');
-  styling.innerHTML = `
-input::-webkit-outer-spin-button,
-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-input[type=number] {
-  -moz-appearance: textfield;
-}
-
-body {
-  font-size: var(--vscode-font-size);
-  font-weight: var(--vscode-font-weight);
-  font-family: var(--vscode-font-family);
-}
-
-button {
-  border: none;
-  padding: 6px 4px;
-  text-align: center;
-  color: var(--vscode-button-foreground);
-  background: var(--vscode-button-background);
-}
-
-button:hover {
-  cursor: pointer;
-  background: var(--vscode-button-hoverBackground);
-}
-
-button:focus {
-  outline-color: var(--vscode-focusBorder);
-}
-
-input:not([type="checkbox"]),
-textarea {
-  border: none;
-  font-family: var(--vscode-font-family);
-  padding: var(--input-padding-vertical) var(--input-padding-horizontal);
-  color: var(--vscode-input-foreground);
-  outline-color: var(--vscode-input-border);
-  background-color: var(--vscode-input-background);
-}
-
-input::placeholder,
-textarea::placeholder {
-  color: var(--vscode-input-placeholderForeground);
-}
-  `;
-  document.body.appendChild(styling);
+  applyVsCodeStyling();
 }
 
 export function setViewerPage() {

--- a/vscode-wpilib/src/riolog/shared/sharedscript.ts
+++ b/vscode-wpilib/src/riolog/shared/sharedscript.ts
@@ -496,6 +496,7 @@ function createButton(id: string, text: string, callback: () => void): HTMLLIEle
   const button = document.createElement('button');
   button.id = id;
   button.style.width = '100%';
+  button.style.marginBottom = '2px';
   button.appendChild(document.createTextNode(text));
   button.addEventListener('click', callback);
   li.appendChild(button);
@@ -548,15 +549,16 @@ function setLivePage() {
   rightList.appendChild(createButton('timestamps', 'Show Timestamps', onShowTimestamps));
   rightList.appendChild(createButton('savelot', 'Save Log', onSaveLog));
   const teamNumberUl = document.createElement('li');
+  teamNumberUl.style.display = 'flex';
+  teamNumberUl.style.flexDirection = 'flex-row';
+  teamNumberUl.style.marginBottom = '2px';
   const teamNumberI = document.createElement('input');
   teamNumberI.id = 'teamNumber';
   teamNumberI.type = 'number';
-  teamNumberI.style.width = '50%';
+  teamNumberI.style.flexGrow = '1';
   const teamNumberB = document.createElement('button');
   teamNumberB.id = 'changeTeamNumber';
-  teamNumberB.style.width = '24.9%';
-  teamNumberB.style.right = '0';
-  teamNumberB.style.position = 'fixed';
+  teamNumberB.style.flexGrow = '1';
   teamNumberB.addEventListener('click', onChangeTeamNumber);
   teamNumberB.appendChild(document.createTextNode('Set Team Number'));
   teamNumberUl.appendChild(teamNumberI);
@@ -566,6 +568,58 @@ function setLivePage() {
   if (autoReconnect !== true) {
     onAutoReconnect();
   }
+
+  const styling = document.createElement('style');
+  styling.innerHTML = `
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type=number] {
+  -moz-appearance: textfield;
+}
+
+body {
+  font-size: var(--vscode-font-size);
+  font-weight: var(--vscode-font-weight);
+  font-family: var(--vscode-font-family);
+}
+
+button {
+  border: none;
+  padding: 6px 4px;
+  text-align: center;
+  color: var(--vscode-button-foreground);
+  background: var(--vscode-button-background);
+}
+
+button:hover {
+  cursor: pointer;
+  background: var(--vscode-button-hoverBackground);
+}
+
+button:focus {
+  outline-color: var(--vscode-focusBorder);
+}
+
+input:not([type="checkbox"]),
+textarea {
+  border: none;
+  font-family: var(--vscode-font-family);
+  padding: var(--input-padding-vertical) var(--input-padding-horizontal);
+  color: var(--vscode-input-foreground);
+  outline-color: var(--vscode-input-border);
+  background-color: var(--vscode-input-background);
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--vscode-input-placeholderForeground);
+}
+  `;
+  document.body.appendChild(styling);
 }
 
 export function setViewerPage() {

--- a/vscode-wpilib/src/webviews/pages/eclipseimportpage.ts
+++ b/vscode-wpilib/src/webviews/pages/eclipseimportpage.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import applyVsCodeStyling from '../vscodestyling';
 import { IEclipseIPCReceive, IEclipseIPCSend } from './eclipseimportpagetypes';
 import { validateProject, validateTeamNumber } from './sharedpages';
 
@@ -74,3 +75,5 @@ window.addEventListener('load', (_: Event) => {
   // tslint:disable-next-line:no-non-null-assertion
   document.getElementById('importProject')!.onclick = importProjectButtonClick;
 });
+
+applyVsCodeStyling();

--- a/vscode-wpilib/src/webviews/pages/gradle2020importpage.ts
+++ b/vscode-wpilib/src/webviews/pages/gradle2020importpage.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import applyVsCodeStyling from '../vscodestyling';
 import { IGradle2020IPCReceive, IGradle2020IPCSend } from './gradle2020importpagetypes';
 import { validateProject, validateTeamNumber } from './sharedpages';
 
@@ -78,3 +79,5 @@ window.addEventListener('load', (_: Event) => {
   // tslint:disable-next-line:no-non-null-assertion
   document.getElementById('importProject')!.onclick = importProjectButtonClick;
 });
+
+applyVsCodeStyling();

--- a/vscode-wpilib/src/webviews/pages/projectcreatorpage.ts
+++ b/vscode-wpilib/src/webviews/pages/projectcreatorpage.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import applyVsCodeStyling from '../vscodestyling';
 import { IProjectIPCReceive, IProjectIPCSend, ProjectType } from './projectcreatorpagetypes';
 import { validateProject, validateTeamNumber } from './sharedpages';
 
@@ -134,3 +135,5 @@ window.addEventListener('load', (_: Event) => {
   // tslint:disable-next-line:no-non-null-assertion
   document.getElementById('generateProject')!.onclick = generateProject;
 });
+
+applyVsCodeStyling();

--- a/vscode-wpilib/src/webviews/vscodestyling.ts
+++ b/vscode-wpilib/src/webviews/vscodestyling.ts
@@ -1,0 +1,55 @@
+const applyVsCodeStyling = () => {
+    const styling = document.createElement('style');
+    styling.innerHTML = `
+    input::-webkit-outer-spin-button,
+        input::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+        }
+
+        input[type=number] {
+        -moz-appearance: textfield;
+        }
+
+        body {
+        font-size: var(--vscode-font-size);
+        font-weight: var(--vscode-font-weight);
+        font-family: var(--vscode-font-family);
+        }
+
+        button {
+        border: none;
+        padding: 6px 4px;
+        text-align: center;
+        color: var(--vscode-button-foreground);
+        background: var(--vscode-button-background);
+        }
+
+        button:hover {
+        cursor: pointer;
+        background: var(--vscode-button-hoverBackground);
+        }
+
+        button:focus {
+        outline-color: var(--vscode-focusBorder);
+        }
+
+        input:not([type="checkbox"]),
+        textarea {
+        border: none;
+        font-family: var(--vscode-font-family);
+        padding: var(--input-padding-vertical) var(--input-padding-horizontal);
+        color: var(--vscode-input-foreground);
+        outline-color: var(--vscode-input-border);
+        background-color: var(--vscode-input-background);
+        }
+
+        input::placeholder,
+        textarea::placeholder {
+        color: var(--vscode-input-placeholderForeground);
+        }
+    `;
+    document.body.appendChild(styling);
+};
+
+export default applyVsCodeStyling;


### PR DESCRIPTION
This basically uses VSCode's button styling (and can probably add more similar styling)

I.e. the RioLog looks like this
![riolog-new](https://user-images.githubusercontent.com/63877260/127748544-dd950ae5-9834-431a-9ec1-9059e4c5f07c.PNG)
when previously it looked like this
![riolog-old](https://user-images.githubusercontent.com/63877260/127748548-eeaf2460-5c2e-4221-8ec6-571122a1768c.PNG)

Similarly:
![createproject-new](https://user-images.githubusercontent.com/63877260/127748588-298e7469-1b51-4203-a523-3fb9f974fa2b.PNG)
![2020import-new](https://user-images.githubusercontent.com/63877260/127748590-4cf9fdf3-edd1-4401-b98f-fa8db947a003.PNG)
![eclipseimport-new](https://user-images.githubusercontent.com/63877260/127748592-6b6bed17-ca63-44e1-9db1-85ccc87c34d0.PNG)

PS. I didn't want to bombard with PRs but the RioLog page is missing the WPILib logo. A suggested fix can be found [here](https://github.com/noamzaks/vscode-wpilib/commit/7bcd50f1ff4bd75e27315e929c4f5047843fa165).