### PR TITLE
Fix java glob for file replacer.

### DIFF
--- a/vscode-wpilib/resources/java_replacements.json
+++ b/vscode-wpilib/resources/java_replacements.json
@@ -1,6 +1,6 @@
 [
   {
-    "fileMatcher": "**/*{.java}",
+    "fileMatcher": "**/*.java",
     "flags": "g",
     "replacements": [
       { "from": "edu[.]wpi[.]cscore[.]AxisCamera", "to": "edu.wpi.first.cscore.AxisCamera" },


### PR DESCRIPTION
Apparently the glob API doesn't work if you only have a single file type to glob in the multiglob regex.