### PR TITLE
Add C:\windows\system32 to path during simulation

### DIFF
--- a/vscode-wpilib/src/java/simulate.ts
+++ b/vscode-wpilib/src/java/simulate.ts
@@ -22,7 +22,7 @@ export async function startSimulation(commands: ISimulateCommands): Promise<void
     HALSIM_EXTENSIONS: commands.extensions,
   };
   if (getIsWindows()) {
-    env.PATH = commands.librarydir;
+    env.PATH = commands.librarydir + ';c:\\windows\\system32\\';
   } else {
     env.DYLD_LIBRARY_PATH = commands.librarydir;
     env.LD_LIBRARY_PATH = commands.librarydir;

--- a/vscode-wpilib/src/java/simulate.ts
+++ b/vscode-wpilib/src/java/simulate.ts
@@ -22,7 +22,7 @@ export async function startSimulation(commands: ISimulateCommands): Promise<void
     HALSIM_EXTENSIONS: commands.extensions,
   };
   if (getIsWindows()) {
-    env.PATH = commands.librarydir + ';c:\\windows\\system32\\';
+    env.PATH = commands.librarydir + ';' + process.env.SYSTEMROOT + '\\system32\\';
   } else {
     env.DYLD_LIBRARY_PATH = commands.librarydir;
     env.LD_LIBRARY_PATH = commands.librarydir;


### PR DESCRIPTION
Fixes chcp not found message. Fixes #477