### PR TITLE
Ignore new glass save files

### DIFF
--- a/vscode-wpilib/resources/gradle/shared/.gitignore
+++ b/vscode-wpilib/resources/gradle/shared/.gitignore
@@ -157,5 +157,6 @@ gradle-app.setting
 .project
 .settings/
 bin/
-imgui.ini
 
+# Simulation GUI and other tools window save file
+*-window.json


### PR DESCRIPTION
Only ignore the -window save file; the others should be fine to check into git.