### PR TITLE
Add an intellisense only project year

### DIFF
--- a/vscode-wpilib/src/extension.ts
+++ b/vscode-wpilib/src/extension.ts
@@ -184,6 +184,11 @@ async function handleAfterTrusted(externalApi: ExternalAPI, context: vscode.Exte
 
         vendorDepsWatcher.onDidDelete(fireEvent, null, context.subscriptions);
 
+        if (prefs.getProjectYear() === 'intellisense') {
+          logger.log('Intellisense only build project found');
+          continue;
+        }
+
         if (prefs.getProjectYear() !== '2022beta') {
           const importPersistantState = new PersistentFolderState('wpilib.2022betapersist', false, w.uri.fsPath);
           if (importPersistantState.Value === false) {


### PR DESCRIPTION
WPilib and vendor deps can use this to always have intellisense, without prompting to keep up to date