### PR TITLE
Add selector to allow windbg preview to be used as C++ debugger

### DIFF
--- a/vscode-wpilib/locale/zh-cn/package.i18n.yaml
+++ b/vscode-wpilib/locale/zh-cn/package.i18n.yaml
@@ -13,6 +13,7 @@ wpilibcore.setSkipTests.title: 设置是否跳过测试API
 wpilibcore.setSkipSelectSimulateExtension.title: Change Skip Selection of Simulation Extensions Setting
 wpilibcore.setSelectDefaultSimulateExtension.title: Change Default Selection of Simulation Extensions Setting
 wpilibcore.setStopSimulationOnEntry.title: 设置是否在进入时停止模拟运行
+wpilibcore.setUseWinDbgX.title: Change Use WinDbg Preview (From Store) as Windows Debugger Setting
 wpilibcore.setStartRioLog.title: 设置是否在部署时启动 RioLog
 wpilibcore.createCommand.title: 创建一个新的类/命令
 wpilibcore.cancelTasks.title: 取消正在运行的任务

--- a/vscode-wpilib/package.json
+++ b/vscode-wpilib/package.json
@@ -31,6 +31,7 @@
         "onCommand:wpilibcore.setSelectDefaultSimulateExtension",
         "onCommand:wpilibcore.setOffline",
         "onCommand:wpilibcore.setStopSimulationOnEntry",
+        "onCommand:wpilibcore.setUseWinDbgX",
         "onCommand:wpilibcore.setStartRioLog",
         "onCommand:wpilibcore.setDeployOffline",
         "onCommand:wpilibcore.createCommand",
@@ -153,8 +154,14 @@
                 },
                 "wpilib.stopSimulationOnEntry": {
                     "type": "boolean",
-                    "default": "false",
+                    "default": false,
                     "description": "Set to make simulation code stop automatically on entry",
+                    "scope": "resource"
+                },
+                "wpilib.useWindbgX": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use WinDbg Preview (from store) as C++ debugger (Windows only)",
                     "scope": "resource"
                 }
             }
@@ -249,6 +256,12 @@
             {
                 "command": "wpilibcore.setStopSimulationOnEntry",
                 "title": "%wpilibcore.setStopSimulationOnEntry.title%",
+                "category": "WPILib",
+                "enablement": "isWorkspaceTrusted"
+            },
+            {
+                "command": "wpilibcore.setUseWinDbgX",
+                "title": "%wpilibcore.setUseWinDbgX.title%",
                 "category": "WPILib",
                 "enablement": "isWorkspaceTrusted"
             },

--- a/vscode-wpilib/package.nls.json
+++ b/vscode-wpilib/package.nls.json
@@ -16,6 +16,7 @@
 	"wpilibcore.setOffline.title": "Change Run Commands Except Deploy/Debug in Offline Mode Setting",
 	"wpilibcore.setDeployOffline.title": "Change Run Deploy/Debug Command in Offline Mode Setting",
 	"wpilibcore.setStopSimulationOnEntry.title": "Change Stop Simulation on Entry Setting",
+	"wpilibcore.setUseWinDbgX.title": "Change Use WinDbg Preview (From Store) as Windows Debugger Setting",
 	"wpilibcore.setStartRioLog.title": "Change Auto Start RioLog on Deploy Setting",
 	"wpilibcore.createCommand.title": "Create a new class/command",
 	"wpilibcore.cancelTasks.title": "Cancel currently running tasks",

--- a/vscode-wpilib/src/cpp/deploydebug.ts
+++ b/vscode-wpilib/src/cpp/deploydebug.ts
@@ -335,7 +335,7 @@ class SimulateCodeDeployer implements ICodeDeployer {
         workspace,
       };
 
-      await startWindowsSimulation(config);
+      await startWindowsSimulation(config, this.executeApi);
     }
     return true;
   }

--- a/vscode-wpilib/src/cpp/simulatewindows.ts
+++ b/vscode-wpilib/src/cpp/simulatewindows.ts
@@ -2,6 +2,7 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { IExecuteAPI } from 'vscode-wpilibapi';
 import { logger } from '../logger';
 
 export interface IWindowsSimulateCommands {
@@ -19,7 +20,26 @@ interface IEnvMap {
   [key: string]: any;
 }
 
-export async function startWindowsSimulation(commands: IWindowsSimulateCommands): Promise<void> {
+export async function simulateWindowsWindbgX(commands: IWindowsSimulateCommands, executor: IExecuteAPI): Promise<void> {
+  let env:  { [key: string]: string } = {
+    HALSIM_EXTENSIONS: commands.extensions,
+  };
+  if (commands.environment !== undefined) {
+    for (const envVar of Object.keys(commands.environment)) {
+      const value = commands.environment[envVar];
+      env[envVar] = value;
+    }
+  }
+  logger.log('C++ WinDbg Simulation', commands.launchfile, commands.workspace.uri.fsPath, env);
+  await executor.executeCommand("WinDbgX " + commands.launchfile, "windbgx", commands.workspace.uri.fsPath, commands.workspace, env);
+}
+
+export async function startWindowsSimulation(commands: IWindowsSimulateCommands, executor: IExecuteAPI): Promise<void> {
+  const wpConfiguration = vscode.workspace.getConfiguration('wpilib', commands.workspace.uri);
+  const res = wpConfiguration.get<boolean>('useWindbgX');
+  if (res === true) {
+    return simulateWindowsWindbgX(commands, executor);
+  }
 
   let symbolSearchPath = '';
 

--- a/vscode-wpilib/src/vscommands.ts
+++ b/vscode-wpilib/src/vscommands.ts
@@ -195,7 +195,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
 
     const result = await globalProjectSettingUpdate(i18n('message', 'Skip tests on deploy? Currently {0}', preferences.getSkipTests()));
     if (result === undefined) {
-      logger.log('Invalid selection for settting skip tests');
+      logger.log('Invalid selection for setting skip tests');
       return;
     }
 
@@ -257,7 +257,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
     const result = await globalProjectSettingUpdate(i18n('message',
       'Run commands other then deploy in offline mode? Currently {0}', preferences.getOffline()));
     if (result === undefined) {
-      logger.log('Invalid selection for settting offline');
+      logger.log('Invalid selection for setting offline');
       return;
     }
 
@@ -277,7 +277,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
     const result = await globalProjectSettingUpdate(i18n('message',
       'Run deploy command in offline mode? Currently {0}', preferences.getDeployOffline()));
     if (result === undefined) {
-      logger.log('Invalid selection for settting deploy offline');
+      logger.log('Invalid selection for setting deploy offline');
       return;
     }
 
@@ -297,11 +297,39 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
     const result = await globalProjectSettingUpdate(i18n('message',
       'Stop simulation debugging on entry? Currently {0}', preferences.getStopSimulationOnEntry()));
     if (result === undefined) {
-      logger.log('Invalid selection for settting stop simulation on entry');
+      logger.log('Invalid selection for setting stop simulation on entry');
       return;
     }
 
     await preferences.setStopSimulationOnEntry(result.yes, result.global);
+  }));
+
+  context.subscriptions.push(vscode.commands.registerCommand('wpilibcore.setUseWinDbgX', async () => {
+    const preferencesApi = externalApi.getPreferencesAPI();
+    const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
+    if (workspace === undefined) {
+      vscode.window.showInformationMessage(i18n('message', 'Cannot set windbgx in an empty workspace'));
+      return;
+    }
+
+    const wpConfiguration = vscode.workspace.getConfiguration('wpilib', workspace.uri);
+    let res = wpConfiguration.get<boolean>('useWindbgX');
+    if (res === undefined) {
+      res = false;
+    }
+
+    const result = await globalProjectSettingUpdate(i18n('message',
+      'Use WinDbg Preview (from store) for windows debugging? Currently {0}', res));
+    if (result === undefined) {
+      logger.log('Invalid selection for setting Use WinDbg Preview');
+      return;
+    }
+
+    let target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global;
+    if (!result.global) {
+      target = vscode.ConfigurationTarget.WorkspaceFolder;
+    }
+    return wpConfiguration.update('useWindbgX', result.yes, target);
   }));
 
   context.subscriptions.push(vscode.commands.registerCommand('wpilibcore.setAutoSave', async () => {


### PR DESCRIPTION
WinDbg Preview is _much_ better at finding symbols then VS Code, and can also use sourcelink to grab straight from GitHub. This makes debugging odd failures much easier.