### PR TITLE
Check for successful project creation before opening

### DIFF
--- a/vscode-wpilib/locale/zh-cn/message.yaml
+++ b/vscode-wpilib/locale/zh-cn/message.yaml
@@ -76,3 +76,4 @@ Tool run canceled: 工具运行取消
 Failed to start tool: 工具运行失败
 No tools found. Would you like to use Gradle to grab some?: 没找到工具，要使用 Gradle 来装一些吗？
 # Can only extract to absolute path
+# Please select project type, language, and base.

--- a/vscode-wpilib/src/shared/exampletemplateapi.ts
+++ b/vscode-wpilib/src/shared/exampletemplateapi.ts
@@ -5,6 +5,7 @@ import { mkdirpAsync, readFileAsync, writeFileAsync } from '../utilities';
 import * as vscode from '../vscodeshim';
 import { ICreatorQuickPick, IExampleTemplateAPI, IExampleTemplateCreator } from '../wpilibapishim';
 import { IPreferencesJson } from './preferencesjson';
+import  { localize as i18n } from '../locale';
 
 export class ExampleTemplateAPI implements IExampleTemplateAPI {
   private templates: ICreatorQuickPick[] = [];
@@ -78,6 +79,7 @@ export class ExampleTemplateAPI implements IExampleTemplateAPI {
         }
       }
     }
+    vscode.window.showErrorMessage(i18n('message', 'Please select project type, language, and base.'));
     return false;
   }
 

--- a/vscode-wpilib/src/webviews/pages/projectcreatorpage.ts
+++ b/vscode-wpilib/src/webviews/pages/projectcreatorpage.ts
@@ -95,8 +95,10 @@ window.addEventListener('message', (event) => {
     case 'projecttype':
       projectType = data.data as ProjectType;
       pType.innerText = ProjectType[projectType].toLowerCase();
+      language = '';
       lang.disabled = false;
       lang.innerText = window.i18nTrans('projectcreator', 'Select a language');
+      base = '';
       baseButton.style.visibility = 'initial';
       baseButton.disabled = true;
       baseButton.innerText = window.i18nTrans('projectcreator', 'Select a project base');
@@ -105,6 +107,7 @@ window.addEventListener('message', (event) => {
     case 'language':
       language = data.data as string;
       lang.innerText = language;
+      base = '';
       baseButton.disabled = false;
       baseButton.innerText = window.i18nTrans('projectcreator', 'Select a project base');
       selectProjectBase();

--- a/vscode-wpilib/src/webviews/projectcreator.ts
+++ b/vscode-wpilib/src/webviews/projectcreator.ts
@@ -72,8 +72,12 @@ export class ProjectCreator extends WebViewBase {
       vscode.window.showErrorMessage(i18n('message', 'Can only extract to absolute path'));
       return;
     }
-    await this.exampleTemplateApi.createProject(data.projectType === ProjectType.Template, data.language, data.base, data.toFolder, data.newFolder,
-      data.projectName, parseInt(data.teamNumber, 10));
+    const successful = await this.exampleTemplateApi.createProject(data.projectType === ProjectType.Template, data.language, data.base,
+      data.toFolder, data.newFolder, data.projectName, parseInt(data.teamNumber, 10));
+
+    if (!successful) {
+      return;
+    }
 
     const toFolder = data.newFolder ? path.join(data.toFolder, data.projectName) : data.toFolder;
 


### PR DESCRIPTION
Fixes multiple issues:

- Project creator ignores `false` (unsuccessful) return from `exampleTemplateApi.createProject`
- Project creator would show error "Cannot create into non empty folder" yet say "Project created successfully" and prompt to open (#404)
- When no project type/language/base selected properly, creator would report successful creation but error when opening project (#228)
- When project type/language/base selected, then clicked again and the user exits the prompt (unselecting the type) creator would cache previous type and use it.

Fixes #228 
Fixes #404 
