### PR TITLE
Use junit-bom for JUnit dependencies.

### DIFF
--- a/vscode-wpilib/resources/gradle/java/build.gradle
+++ b/vscode-wpilib/resources/gradle/java/build.gradle
@@ -65,9 +65,10 @@ dependencies {
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
     simulationRelease wpi.sim.enableRelease()
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    testImplementation platform('org.junit:junit-bom:5.8.2')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 
 test {

--- a/vscode-wpilib/resources/gradle/javadt/build.gradle
+++ b/vscode-wpilib/resources/gradle/javadt/build.gradle
@@ -16,9 +16,10 @@ dependencies {
     nativeRelease wpi.java.deps.wpilibJniRelease(wpi.platforms.desktop)
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    testImplementation platform('org.junit:junit-bom:5.8.2')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 
 test {

--- a/vscode-wpilib/resources/gradle/javaromi/build.gradle
+++ b/vscode-wpilib/resources/gradle/javaromi/build.gradle
@@ -25,9 +25,10 @@ dependencies {
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
     simulationRelease wpi.sim.enableRelease()
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    testImplementation platform('org.junit:junit-bom:5.8.2')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 
 test {


### PR DESCRIPTION
With the changed to using JUnit 5 in 2023, it would be preferable to use the `junit-bom` for managing all JUnit dependencies. 

BOM (Bill of Materials) files make version management easier -- since when upgrading JUnit, a version number change is only needed in one place -- and ensure a consistent version of JUnit artifacts are used throughout the project, even when pulled in transitively. For example, if a user where to add an additional testing library or framework that transitively pulls in  (as an example) version 5.6.3 of `junit-vintage-engine`, the BOM would result in that being upgraded to the same version as the BOM, v5.8.2 in this example. Without the BOM, version 5.6.2 of `junit-vintage-engine` would get used, resulting in a mismatch of JUnit artifacts.


**References:**

- JUnit 5 User Guide [§10.2.4. Bill of Materials (BOM)](https://junit.org/junit5/docs/current/user-guide/#dependency-metadata-junit-bom)
- Gradle User Guide [Using bills of materials (BOMs)](https://docs.gradle.org/7.5.1/userguide/migrating_from_maven.html#migmvn:using_boms)
- [Gradle Goodness: Use Bill of Materials (BOM) as Dependency Constraints](https://dzone.com/articles/gradle-goodness-use-bill-of-materials-bom-as-depen)
- [Using Maven’s Bill of Materials (BOM)](https://reflectoring.io/maven-bom/)
    - A detailed article explaining the benefits of BOMs.
    - While this article focuses on BOMs use in Maven, the concepts apply to Gradle as well