### PR TITLE
Fix deprecated java plugin conventions

### DIFF
--- a/vscode-wpilib/resources/gradle/java/build.gradle
+++ b/vscode-wpilib/resources/gradle/java/build.gradle
@@ -3,8 +3,10 @@ plugins {
     id "edu.wpi.first.GradleRIO" version "###GRADLERIOREPLACE###"
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 def ROBOT_MAIN_CLASS = "###ROBOTCLASSREPLACE###"
 

--- a/vscode-wpilib/resources/gradle/javadt/build.gradle
+++ b/vscode-wpilib/resources/gradle/javadt/build.gradle
@@ -3,6 +3,11 @@ plugins {
     id "edu.wpi.first.GradleRIO" version "###GRADLERIOREPLACE###"
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
 def ROBOT_MAIN_CLASS = "###ROBOTCLASSREPLACE###"
 
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.

--- a/vscode-wpilib/resources/gradle/javaromi/build.gradle
+++ b/vscode-wpilib/resources/gradle/javaromi/build.gradle
@@ -3,8 +3,10 @@ plugins {
     id "edu.wpi.first.GradleRIO" version "###GRADLERIOREPLACE###"
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 def ROBOT_MAIN_CLASS = "###ROBOTCLASSREPLACE###"
 

--- a/vscode-wpilib/resources/gradle/javaxrp/build.gradle
+++ b/vscode-wpilib/resources/gradle/javaxrp/build.gradle
@@ -3,8 +3,10 @@ plugins {
     id "edu.wpi.first.GradleRIO" version "###GRADLERIOREPLACE###"
 }
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 def ROBOT_MAIN_CLASS = "###ROBOTCLASSREPLACE###"
 


### PR DESCRIPTION
Now that WPILib has decided to use Gradle 8.x, there are deprecation warnings in the default `build.gradle` files in project templates/examples. The following PR fixes the deprecation warnings. (More detail [here](https://docs.gradle.org/current/userguide/upgrading_version_8.html#java_convention_deprecation))

~~I have also bumped the Java version now too.~~