### PR TITLE
Workaround for gradle rebuilding headers in C++ user projects

### DIFF
--- a/vscode-wpilib/resources/gradle/shared/settings.gradle
+++ b/vscode-wpilib/resources/gradle/shared/settings.gradle
@@ -25,3 +25,6 @@ pluginManagement {
         }
     }
 }
+
+Properties props = System.getProperties();
+props.setProperty("org.gradle.internal.native.headers.unresolved.dependencies.ignore", "true");


### PR DESCRIPTION
Fixes https://github.com/wpilibsuite/GradleRIO/issues/657