### PR TITLE
Cancel sim when escape is pressed at extension selection

### DIFF
--- a/vscode-wpilib/src/java/deploydebug.ts
+++ b/vscode-wpilib/src/java/deploydebug.ts
@@ -262,11 +262,13 @@ class SimulateCodeDeployer implements ICodeDeployer {
           canPickMany: true,
           placeHolder: 'Pick extensions to run',
         });
-        if (quickPick !== undefined) {
-          for (const qp of quickPick) {
-            extensions += qp.path;
-            extensions += path.delimiter;
-          }
+        if (quickPick === undefined) {
+          vscode.window.showInformationMessage('Simulation cancelled');
+          return false;
+        }
+        for (const qp of quickPick) {
+          extensions += qp.path;
+          extensions += path.delimiter;
         }
       }
     }


### PR DESCRIPTION
Also cancels if you alt-tab away or click out of the selection quickpick.