### PR TITLE
Add .wpilog to template gitignore

### DIFF
--- a/vscode-wpilib/resources/gradle/shared/.gitignore
+++ b/vscode-wpilib/resources/gradle/shared/.gitignore
@@ -174,5 +174,8 @@ out/
 # Simulation data log directory
 logs/
 
+# WPI simulation data logs
+.wpilog
+
 # Folder that has CTRE Phoenix Sim device config storage
 ctre_sim/


### PR DESCRIPTION
WPILogs are dumped in the project root when using DataLogManager in simulation. This just keeps them from being inadvertently checked into git by default.