### PR TITLE
Extract unit tests to examples and templates with flag set

### DIFF
--- a/vscode-wpilib/src/shared/examples.ts
+++ b/vscode-wpilib/src/shared/examples.ts
@@ -16,6 +16,7 @@ export interface IExampleJsonLayout {
   gradlebase: string;
   commandversion: number;
   extravendordeps?: string[];
+  hasunittests?: boolean;
 }
 
 export class Examples {
@@ -23,6 +24,7 @@ export class Examples {
 
   constructor(resourceRoot: string, java: boolean, core: IExampleTemplateAPI) {
     const examplesFolder = path.join(resourceRoot, 'src', 'examples');
+    const examplesTestFolder = path.join(resourceRoot, 'src', 'examples_test');
     const resourceFile = path.join(examplesFolder, this.exampleResourceName);
     const gradleBasePath = path.join(path.dirname(resourceRoot), 'gradle');
     fs.readFile(resourceFile, 'utf8', (err, data) => {
@@ -45,16 +47,20 @@ export class Examples {
           },
           async generate(folderInto: vscode.Uri): Promise<boolean> {
             try {
+              let testFolder;
+              if (e.hasunittests === true) {
+                testFolder = path.join(examplesTestFolder, e.foldername);
+              }
               if (java) {
-                if (!await generateCopyJava(resourceRoot, path.join(examplesFolder, e.foldername),
+                if (!await generateCopyJava(resourceRoot, path.join(examplesFolder, e.foldername), testFolder,
                   path.join(gradleBasePath, e.gradlebase), folderInto.fsPath, 'frc.robot.Main', path.join('frc', 'robot'),
                   false, extraVendordeps)) {
                   vscode.window.showErrorMessage(i18n('message', 'Cannot create into non empty folder'));
                   return false;
                 }
               } else {
-                if (!await generateCopyCpp(resourceRoot, path.join(examplesFolder, e.foldername),
-                  path.join(gradleBasePath, e.gradlebase), folderInto.fsPath, false, false, extraVendordeps)) {
+                if (!await generateCopyCpp(resourceRoot, path.join(examplesFolder, e.foldername), testFolder,
+                  path.join(gradleBasePath, e.gradlebase), folderInto.fsPath, false, extraVendordeps)) {
                   vscode.window.showErrorMessage(i18n('message', 'Cannot create into non empty folder'));
                   return false;
                 }

--- a/vscode-wpilib/src/shared/generator.ts
+++ b/vscode-wpilib/src/shared/generator.ts
@@ -163,7 +163,7 @@ export async function generateCopyJava(resourcesFolder: string, fromTemplateFold
     if (fromTemplateTestFolder !== undefined) {
       const testFiles = await new Promise<string[]>((resolve, reject) => {
         glob('**/*{.java,.gradle}', {
-          cwd: codePath,
+          cwd: testPath,
           nodir: true,
           nomount: true,
         }, (err, matches) => {

--- a/vscode-wpilib/src/shared/templates.ts
+++ b/vscode-wpilib/src/shared/templates.ts
@@ -16,6 +16,7 @@ export interface ITemplateJsonLayout {
   gradlebase: string;
   commandversion: number;
   extravendordeps?: string[];
+  hasunittests?: boolean;
 }
 
 export class Templates {
@@ -23,6 +24,7 @@ export class Templates {
 
   constructor(resourceRoot: string, java: boolean, core: IExampleTemplateAPI) {
     const templatesFolder = path.join(resourceRoot, 'src', 'templates');
+    const templatesTestFolder = path.join(resourceRoot, 'src', 'templates_test');
     const resourceFile = path.join(templatesFolder, this.exampleResourceName);
     const gradleBasePath = path.join(path.dirname(resourceRoot), 'gradle');
     fs.readFile(resourceFile, 'utf8', (err, data) => {
@@ -45,16 +47,20 @@ export class Templates {
           },
           async generate(folderInto: vscode.Uri): Promise<boolean> {
             try {
+              let testFolder;
+              if (e.hasunittests === true) {
+                testFolder = path.join(templatesTestFolder, e.foldername);
+              }
               if (java) {
-                if (!await generateCopyJava(resourceRoot, path.join(templatesFolder, e.foldername),
+                if (!await generateCopyJava(resourceRoot, path.join(templatesFolder, e.foldername), testFolder,
                   path.join(gradleBasePath, e.gradlebase), folderInto.fsPath, 'frc.robot.Main', path.join('frc', 'robot'),
                   false, extraVendordeps)) {
                   vscode.window.showErrorMessage(i18n('message', 'Cannot create into non empty folder'));
                   return false;
                 }
               } else {
-                if (!await generateCopyCpp(resourceRoot, path.join(templatesFolder, e.foldername),
-                  path.join(gradleBasePath, e.gradlebase), folderInto.fsPath, false, false, extraVendordeps)) {
+                if (!await generateCopyCpp(resourceRoot, path.join(templatesFolder, e.foldername), testFolder,
+                  path.join(gradleBasePath, e.gradlebase), folderInto.fsPath, false, extraVendordeps)) {
                   vscode.window.showErrorMessage(i18n('message', 'Cannot create into non empty folder'));
                   return false;
                 }

--- a/vscode-wpilib/src/shared/vendorexamples.ts
+++ b/vscode-wpilib/src/shared/vendorexamples.ts
@@ -72,15 +72,15 @@ export async function addVendorExamples(resourceRoot: string, core: IExampleTemp
               async generate(folderInto: vscode.Uri): Promise<boolean> {
                 try {
                   if (ex.language === 'java') {
-                    if (!await generateCopyJava(shimmedResourceRoot, path.join(exampleDir, ex.foldername),
+                    if (!await generateCopyJava(shimmedResourceRoot, path.join(exampleDir, ex.foldername), undefined,
                       path.join(gradleBasePath, ex.gradlebase), folderInto.fsPath, 'frc.robot.' + ex.mainclass,
                       path.join('frc', 'robot'), false, extraVendordeps, ex.packagetoreplace)) {
                       vscode.window.showErrorMessage(i18n('message', 'Cannot create into non empty folder'));
                       return false;
                     }
                   } else {
-                    if (!await generateCopyCpp(shimmedResourceRoot, path.join(exampleDir, ex.foldername),
-                      path.join(gradleBasePath, ex.gradlebase), folderInto.fsPath, false, false, extraVendordeps)) {
+                    if (!await generateCopyCpp(shimmedResourceRoot, path.join(exampleDir, ex.foldername), undefined,
+                      path.join(gradleBasePath, ex.gradlebase), folderInto.fsPath, false, extraVendordeps)) {
                       vscode.window.showErrorMessage(i18n('message', 'Cannot create into non empty folder'));
                       return false;
                     }

--- a/vscode-wpilib/src/webviews/gradle2020import.ts
+++ b/vscode-wpilib/src/webviews/gradle2020import.ts
@@ -248,11 +248,11 @@ export class Gradle2020Import extends WebViewBase {
     let success = false;
     if (cpp) {
       const gradlePath = path.join(gradleBasePath, data.romi ? 'cppromi' : 'cpp');
-      success = await generateCopyCpp(path.join(resourceRoot, 'cpp'), path.join(oldProjectPath, 'src'), gradlePath, toFolder,
-                                       false, true, []);
+      success = await generateCopyCpp(path.join(resourceRoot, 'cpp'), path.join(oldProjectPath, 'src'), undefined, gradlePath, toFolder,
+                                       true, []);
     } else {
       const gradlePath = path.join(gradleBasePath, data.romi ? 'javaromi' : 'java');
-      success = await generateCopyJava(path.join(resourceRoot, 'java'), path.join(oldProjectPath, 'src'), gradlePath, toFolder,
+      success = await generateCopyJava(path.join(resourceRoot, 'java'), path.join(oldProjectPath, 'src'), undefined, gradlePath, toFolder,
                                        javaRobotPackage, '', true, []);
     }
 

--- a/wpilib-utility-standalone/src/generatorscript.ts
+++ b/wpilib-utility-standalone/src/generatorscript.ts
@@ -211,7 +211,7 @@ async function handleCppCreate(_item: IDisplayJSON, _srcRoot: string): Promise<v
   const toFolder = dirArr[0];
 
   const templateFolder = path.join(_srcRoot, _item.foldername);
-  const result = await generateCopyCpp(resourceRoot, templateFolder, path.join(gradleRoot, _item.gradlebase), toFolder, false, false, []);
+  const result = await generateCopyCpp(resourceRoot, templateFolder, undefined, path.join(gradleRoot, _item.gradlebase), toFolder, false, []);
   if (!result) {
     await dialog.showMessageBox({
       message: 'Cannot extract into non empty directory',
@@ -228,7 +228,7 @@ async function handleJavaCreate(_item: IDisplayJSON, _srcRoot: string): Promise<
   const toFolder = dirArr[0];
 
   const templateFolder = path.join(_srcRoot, _item.foldername);
-  const result = await generateCopyJava(resourceRoot, templateFolder, path.join(gradleRoot, _item.gradlebase), toFolder,
+  const result = await generateCopyJava(resourceRoot, templateFolder, undefined, path.join(gradleRoot, _item.gradlebase), toFolder,
                                         'frc.robot.Robot', path.join('frc', 'robot'), false, []);
 
   if (!result) {


### PR DESCRIPTION
Recent allwpilib changes added unit tests to some projects in a way to be copyable to robot projects. Properly copy those outputs to the generated robot project.