### PR TITLE
Fix junit-platform-launcher definition

### DIFF
--- a/vscode-wpilib/resources/gradle/java/build.gradle
+++ b/vscode-wpilib/resources/gradle/java/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     simulationRelease wpi.sim.enableRelease()
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.1'
 }
 
 test {

--- a/vscode-wpilib/resources/gradle/javadt/build.gradle
+++ b/vscode-wpilib/resources/gradle/javadt/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.1'
 }
 
 test {

--- a/vscode-wpilib/resources/gradle/javaromi/build.gradle
+++ b/vscode-wpilib/resources/gradle/javaromi/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     simulationRelease wpi.sim.enableRelease()
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.1'
 }
 
 test {

--- a/vscode-wpilib/resources/gradle/javaxrp/build.gradle
+++ b/vscode-wpilib/resources/gradle/javaxrp/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     simulationRelease wpi.sim.enableRelease()
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.1'
 }
 
 test {

--- a/vscode-wpilib/src/extension.ts
+++ b/vscode-wpilib/src/extension.ts
@@ -216,7 +216,7 @@ async function handleAfterTrusted(externalApi: ExternalAPI, context: vscode.Exte
               gradleBuildFile =gradleBuildFile.replace("testRuntimeOnly 'org.junit.platform:junit-platform-launcher'", "testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.1'")
               await writeFileAsync(path.join(w.uri.fsPath, 'build.gradle'), gradleBuildFile);
               projectFix202411.Value = true;
-              await vscode.window.showInformationMessage("Project was updated to fix java test dependnecy issues. Please commit the change. This change will not trigger again if changes are not saved", {
+              await vscode.window.showInformationMessage("Project was updated to fix java test dependency issues. Please commit the change. This change will not trigger again if changes are not saved", {
                 modal: true
               });
             }


### PR DESCRIPTION
The installer doesn't grab gradle module files, which makes the junit-platform-launcher dependency without a version fail if the installer is used. Fixing this in the installer is not going to be easy, so the solution for now is to just fix the projects, and put a fixer in VS Code to automatically fix the project.