### PR TITLE
Update build templates for gradlerio deploy files

### DIFF
--- a/vscode-wpilib/resources/gradle/c/build.gradle
+++ b/vscode-wpilib/resources/gradle/c/build.gradle
@@ -29,6 +29,12 @@ deploy {
                     files = project.fileTree('src/main/deploy')
                     directory = '/home/lvuser/deploy'
                 }
+
+                // deploy and debug info artifact
+                frcStaticFileDeploy(getArtifactTypeClass('FileTreeArtifact')) {
+                    files = project.fileTree('build/debug/')
+                    directory = '/home/lvuser/debug'
+                }
             }
         }
     }

--- a/vscode-wpilib/resources/gradle/cpp/build.gradle
+++ b/vscode-wpilib/resources/gradle/cpp/build.gradle
@@ -28,6 +28,12 @@ deploy {
                     files = project.fileTree('src/main/deploy')
                     directory = '/home/lvuser/deploy'
                 }
+
+                // deploy and debug info artifact
+                frcStaticFileDeploy(getArtifactTypeClass('FileTreeArtifact')) {
+                    files = project.fileTree('build/debug/')
+                    directory = '/home/lvuser/debug'
+                }
             }
         }
     }

--- a/vscode-wpilib/resources/gradle/java/build.gradle
+++ b/vscode-wpilib/resources/gradle/java/build.gradle
@@ -34,6 +34,12 @@ deploy {
                     files = project.fileTree('src/main/deploy')
                     directory = '/home/lvuser/deploy'
                 }
+
+                // deploy and debug info artifact
+                frcStaticFileDeploy(getArtifactTypeClass('FileTreeArtifact')) {
+                    files = project.fileTree('build/debug/')
+                    directory = '/home/lvuser/debug'
+                }
             }
         }
     }


### PR DESCRIPTION
Requires https://github.com/wpilibsuite/GradleRIO/pull/690

This should still work without this but will only have the debug info file not the deploy.json