### PR TITLE
Update Set VS Code Java Home setting

### DIFF
--- a/vscode-wpilib/src/vscommands.ts
+++ b/vscode-wpilib/src/vscommands.ts
@@ -382,8 +382,8 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       return;
     }
     const javaConfig = vscode.workspace.getConfiguration('java');
-    await javaConfig.update('home', javaHome, vscode.ConfigurationTarget.Global);
-    await vscode.window.showInformationMessage(i18n('message', 'Successfully set java.home'));
+    await javaConfig.update('jdt.ls.java.home', javaHome, vscode.ConfigurationTarget.Global);
+    await vscode.window.showInformationMessage(i18n('message', 'Successfully set java.jdt.ls.java.home'));
   }));
 
   context.subscriptions.push(vscode.commands.registerCommand('wpilibcore.installGradleTools', async () => {


### PR DESCRIPTION
java.home is deprecated. Corollary to #611