### PR TITLE
Add epilogue support

### DIFF
--- a/vscode-wpilib/resources/gradle/java/build.gradle
+++ b/vscode-wpilib/resources/gradle/java/build.gradle
@@ -50,6 +50,7 @@ def includeDesktopSupport = false
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 5.
 dependencies {
+    annotationProcessor wpi.java.deps.wpilibAnnotations()
     implementation wpi.java.deps.wpilib()
     implementation wpi.java.vendor.java()
 

--- a/vscode-wpilib/resources/gradle/javadt/build.gradle
+++ b/vscode-wpilib/resources/gradle/javadt/build.gradle
@@ -13,6 +13,7 @@ def ROBOT_MAIN_CLASS = "###ROBOTCLASSREPLACE###"
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 5.
 dependencies {
+    annotationProcessor wpi.java.deps.wpilibAnnotations()
     implementation wpi.java.deps.wpilib()
 
     nativeDebug wpi.java.deps.wpilibJniDebug(wpi.platforms.desktop)

--- a/vscode-wpilib/resources/gradle/javaromi/build.gradle
+++ b/vscode-wpilib/resources/gradle/javaromi/build.gradle
@@ -16,6 +16,7 @@ def includeDesktopSupport = true
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 5.
 dependencies {
+    annotationProcessor wpi.java.deps.wpilibAnnotations()
     implementation wpi.java.deps.wpilib()
     implementation wpi.java.vendor.java()
 

--- a/vscode-wpilib/resources/gradle/javaxrp/build.gradle
+++ b/vscode-wpilib/resources/gradle/javaxrp/build.gradle
@@ -16,6 +16,7 @@ def includeDesktopSupport = true
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 5.
 dependencies {
+    annotationProcessor wpi.java.deps.wpilibAnnotations()
     implementation wpi.java.deps.wpilib()
     implementation wpi.java.vendor.java()
 


### PR DESCRIPTION
Use the new wpilibAnnotations() dependency group, which includes epilogue

The runtime is included in the existing wpilib() group, so only the annotation processors need to be added

Relies on https://github.com/wpilibsuite/GradleRIO/pull/744