### PR TITLE
RioLog: don't connect to localhost

### DIFF
--- a/libraries/wpilib-riolog/src/rioconnector.ts
+++ b/libraries/wpilib-riolog/src/rioconnector.ts
@@ -29,8 +29,9 @@ interface IDriverStationData {
 }
 
 const constantIps: string[] = [
-  '172.22.11.2',
-  '127.0.0.1',
+  '172.22.11.2'
+  //, '127.0.0.1',
+  // Uncomment the above line for testing on localhost.
 ];
 
 const teamIps: string[] = [
@@ -239,6 +240,7 @@ export async function connectToRobot(port: number, teamNumber: number, timeout: 
   } else {
     // Kill all but me
     timer.cancel();
+    console.log("Using " + firstDone.remoteAddress + ", disposing others");
     for (const p of pairs) {
       if (firstDone !== p.socket) {
         p.dispose();


### PR DESCRIPTION
127.0.0.1 was used for testing. The DS sends data to dashboards on localhost:1741, so some dashboards listen for a connection from driver station, and riolog will connect (but no data will be sent).
Also logs which connection is actually used.