### PR TITLE
Don't exclude .gitignore from copy to standalone tool

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,10 @@
+import org.apache.tools.ant.DirectoryScanner
+
 pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
     }
 }
+
+DirectoryScanner.removeDefaultExclude('**/.gitignore')


### PR DESCRIPTION
Fixes #689
https://docs.gradle.org/current/userguide/working_with_files.html#sec:file_trees