### PR TITLE
Fix eslint ignore

### DIFF
--- a/vscode-wpilib/.eslintignore
+++ b/vscode-wpilib/.eslintignore
@@ -1,6 +1,0 @@
-.eslintrc.js
-out
-resources
-webpack.config.js
-gulpfile.js
-dist

--- a/vscode-wpilib/eslint.config.js
+++ b/vscode-wpilib/eslint.config.js
@@ -1,5 +1,5 @@
 // eslint.config.js
 module.exports =
   {
-      ignores: ["media/", "out/", "resources/"]
+      ignores: ["media/", "out/", "resources/", ".eslintrc.js", "webpack.config.js", "gulpfile.js", "dist"]
   };


### PR DESCRIPTION
some ignores were in .eslintignore which is deprecated. When eslint.config.js was added, they stopped being used. Add all entries from .eslintignore into eslint.config.js