### PR TITLE
Add case sensitive file support to C++ projects

### DIFF
--- a/vscode-wpilib/resources/gradle/c/.vscode/settings.json
+++ b/vscode-wpilib/resources/gradle/c/.vscode/settings.json
@@ -14,5 +14,6 @@
     "**/.factorypath": true,
     "**/*~": true
   },
-  "C_Cpp.default.configurationProvider": "vscode-wpilib"
+  "C_Cpp.default.configurationProvider": "vscode-wpilib",
+  "C_Cpp.caseSensitiveFileSupport": "enabled",
 }

--- a/vscode-wpilib/resources/gradle/cpp/.vscode/settings.json
+++ b/vscode-wpilib/resources/gradle/cpp/.vscode/settings.json
@@ -14,5 +14,6 @@
     "**/.factorypath": true,
     "**/*~": true
   },
-  "C_Cpp.default.configurationProvider": "vscode-wpilib"
+  "C_Cpp.default.configurationProvider": "vscode-wpilib",
+  "C_Cpp.caseSensitiveFileSupport": "enabled",
 }

--- a/vscode-wpilib/resources/gradle/cppromi/.vscode/settings.json
+++ b/vscode-wpilib/resources/gradle/cppromi/.vscode/settings.json
@@ -15,5 +15,6 @@
     "**/*~": true
   },
   "C_Cpp.default.configurationProvider": "vscode-wpilib",
-  "wpilib.skipSelectSimulateExtension": true
+  "wpilib.skipSelectSimulateExtension": true,
+  "C_Cpp.caseSensitiveFileSupport": "enabled",
 }

--- a/vscode-wpilib/resources/gradle/cppxrp/.vscode/settings.json
+++ b/vscode-wpilib/resources/gradle/cppxrp/.vscode/settings.json
@@ -15,5 +15,6 @@
     "**/*~": true
   },
   "C_Cpp.default.configurationProvider": "vscode-wpilib",
-  "wpilib.skipSelectSimulateExtension": true
+  "wpilib.skipSelectSimulateExtension": true,
+  "C_Cpp.caseSensitiveFileSupport": "enabled",
 }


### PR DESCRIPTION
The extension provider requires this in order to get a case sensitive file url from the extension