### PR TITLE
Revert "Add case sensitive file support to C++ projects (#701)"

### DIFF
--- a/vscode-wpilib/resources/gradle/c/.vscode/settings.json
+++ b/vscode-wpilib/resources/gradle/c/.vscode/settings.json
@@ -14,6 +14,5 @@
     "**/.factorypath": true,
     "**/*~": true
   },
-  "C_Cpp.default.configurationProvider": "vscode-wpilib",
-  "C_Cpp.caseSensitiveFileSupport": "enabled",
+  "C_Cpp.default.configurationProvider": "vscode-wpilib"
 }

--- a/vscode-wpilib/resources/gradle/cpp/.vscode/settings.json
+++ b/vscode-wpilib/resources/gradle/cpp/.vscode/settings.json
@@ -14,6 +14,5 @@
     "**/.factorypath": true,
     "**/*~": true
   },
-  "C_Cpp.default.configurationProvider": "vscode-wpilib",
-  "C_Cpp.caseSensitiveFileSupport": "enabled",
+  "C_Cpp.default.configurationProvider": "vscode-wpilib"
 }

--- a/vscode-wpilib/resources/gradle/cppromi/.vscode/settings.json
+++ b/vscode-wpilib/resources/gradle/cppromi/.vscode/settings.json
@@ -15,6 +15,5 @@
     "**/*~": true
   },
   "C_Cpp.default.configurationProvider": "vscode-wpilib",
-  "wpilib.skipSelectSimulateExtension": true,
-  "C_Cpp.caseSensitiveFileSupport": "enabled",
+  "wpilib.skipSelectSimulateExtension": true
 }

--- a/vscode-wpilib/resources/gradle/cppxrp/.vscode/settings.json
+++ b/vscode-wpilib/resources/gradle/cppxrp/.vscode/settings.json
@@ -15,6 +15,5 @@
     "**/*~": true
   },
   "C_Cpp.default.configurationProvider": "vscode-wpilib",
-  "wpilib.skipSelectSimulateExtension": true,
-  "C_Cpp.caseSensitiveFileSupport": "enabled",
+  "wpilib.skipSelectSimulateExtension": true
 }


### PR DESCRIPTION
Fixed in CPP extension 1.22.9.

This reverts commit 20caca9dc515775e78f800f3aa594d200d48b633.