### PR TITLE
Update Java build.gradle files with eclipse workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 .project
 .settings/
 build/
+.idea/

--- a/vscode-wpilib/resources/gradle/java/build.gradle
+++ b/vscode-wpilib/resources/gradle/java/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "###GRADLERIOREPLACE###"
+    id "eclipse"
 }
 
 java {
@@ -100,4 +101,17 @@ wpi.java.configureTestTasks(test)
 // Configure string concat to always inline compile
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
+}
+
+// Prevent the eclipse compiler (used by the VS Code extension for intellisense and debugging)
+// from generating bad class files from annotation processors like Epilogue
+eclipse {
+    classpath {
+        containers 'org.eclipse.buildship.core.gradleclasspathcontainer'
+        file.whenMerged { cp ->
+            def entries = cp.entries;
+            def src = new org.gradle.plugins.ide.eclipse.model.SourceFolder('build/generated/sources/annotationProcessor/java/main/', null)
+            entries.add(src)
+        }
+    }
 }

--- a/vscode-wpilib/resources/gradle/javaromi/build.gradle
+++ b/vscode-wpilib/resources/gradle/javaromi/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "###GRADLERIOREPLACE###"
+    id "eclipse"
 }
 
 java {
@@ -61,4 +62,17 @@ wpi.java.configureTestTasks(test)
 // Configure string concat to always inline compile
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
+}
+
+// Prevent the eclipse compiler (used by the VS Code extension for intellisense and debugging)
+// from generating bad class files from annotation processors like Epilogue
+eclipse {
+    classpath {
+        containers 'org.eclipse.buildship.core.gradleclasspathcontainer'
+        file.whenMerged { cp ->
+            def entries = cp.entries;
+            def src = new org.gradle.plugins.ide.eclipse.model.SourceFolder('build/generated/sources/annotationProcessor/java/main/', null)
+            entries.add(src)
+        }
+    }
 }

--- a/vscode-wpilib/resources/gradle/javaxrp/build.gradle
+++ b/vscode-wpilib/resources/gradle/javaxrp/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "###GRADLERIOREPLACE###"
+    id "eclipse"
 }
 
 java {
@@ -60,4 +61,17 @@ wpi.java.configureTestTasks(test)
 // Configure string concat to always inline compile
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
+}
+
+// Prevent the eclipse compiler (used by the VS Code extension for intellisense and debugging)
+// from generating bad class files from annotation processors like Epilogue
+eclipse {
+    classpath {
+        containers 'org.eclipse.buildship.core.gradleclasspathcontainer'
+        file.whenMerged { cp ->
+            def entries = cp.entries;
+            def src = new org.gradle.plugins.ide.eclipse.model.SourceFolder('build/generated/sources/annotationProcessor/java/main/', null)
+            entries.add(src)
+        }
+    }
 }


### PR DESCRIPTION
The included configuration should prevent the eclipse compiler from generating partial/corrupt epilogue classes, allowing simulation, debugging, and intellisense to work

Closes #716 (OBE)
Resolves https://github.com/wpilibsuite/allwpilib/issues/7103
Resolves https://github.com/wpilibsuite/2025Beta/issues/20

Thanks to https://github.com/redhat-developer/vscode-java/issues/1660#issuecomment-818274055

(I also added Jetbrains IDE files to the gitignore, since I made these changes in webstorm)