### PR TITLE
Fix Gradle deprecation warning in settings.gradle

### DIFF
--- a/vscode-wpilib/resources/gradle/shared/settings.gradle
+++ b/vscode-wpilib/resources/gradle/shared/settings.gradle
@@ -20,8 +20,8 @@ pluginManagement {
         }
         def frcHomeMaven = new File(frcHome, 'maven')
         maven {
-            name 'frcHome'
-            url frcHomeMaven
+            name = 'frcHome'
+            url = frcHomeMaven
         }
     }
 }


### PR DESCRIPTION
When running `./gradlew build` using Gradle 8.12 or higher (WPILib 2025.1.1 uses 8.11), the following output is shown:

```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
```

When more info is requested, the deprecation is as follows:

```
Settings file 'robot/settings.gradle': line 23
Space-assignment syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('name = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
        at settings_bsoh050aq8icg3omjmmbz5bm0$_run_closure1$_closure2$_closure3.doCall$original(robot/settings.gradle:23)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at settings_bsoh050aq8icg3omjmmbz5bm0$_run_closure1$_closure2.doCall$original(robot/settings.gradle:22)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Settings file 'robot/settings.gradle': line 24
Space-assignment syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('url = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
        at settings_bsoh050aq8icg3omjmmbz5bm0$_run_closure1$_closure2$_closure3.doCall$original(robot/settings.gradle:24)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at settings_bsoh050aq8icg3omjmmbz5bm0$_run_closure1$_closure2.doCall$original(robot/settings.gradle:22)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

The provided two line change fixes these two issues for projects of all languages, and is enough to make the entire deprecation warning disappear for Java projects.