### PR TITLE
Fix blank window after installing dependency from local copy

### DIFF
--- a/vscode-wpilib/src/dependencyView.ts
+++ b/vscode-wpilib/src/dependencyView.ts
@@ -16,7 +16,7 @@ export interface IJsonList {
   uuid: string;
   description: string;
   website: string;
-  instructions: string;
+  instructions?: string;
 }
 
 export interface IDepInstalled {
@@ -457,7 +457,6 @@ export class DependencyViewProvider implements vscode.WebviewViewProvider {
         uuid: i18n('ui', homedep.uuid),
         description: i18n('ui', 'Loaded from Local Copy'),
         website: i18n('ui', 'Loaded from Local Copy'),
-        instructions: i18n('ui', 'Loaded from Local Copy'),
       };
       const found = this.onlineDeps.find(
         (onlinedep) => onlinedep.uuid === depList.uuid && onlinedep.version === depList.version

--- a/vscode-wpilib/src/extension.ts
+++ b/vscode-wpilib/src/extension.ts
@@ -548,6 +548,10 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.window.showErrorMessage('URL not provided!');
         return;
       }
+      if(!URL.canParse(url)) {
+        vscode.window.showErrorMessage(`Could not display website! Invalid URL: "${url}"`);
+        return;
+      }
       if (!tabTitle) {
         tabTitle = 'My Website'; // fallback title if not provided
       }


### PR DESCRIPTION
The instructions key is optional, and if it exists it should contain a valid URL.