### PR TITLE
Use Simple Browser instead of webview to show vendordep instructions

### DIFF
--- a/vscode-wpilib/package.json
+++ b/vscode-wpilib/package.json
@@ -55,8 +55,7 @@
         "onCommand:wpilibcore.openApiDocumentation",
         "onCommand:wpilibcore.getProjectInformation",
         "onCommand:wpilibcore.runGradleClean",
-        "onCommand:wpilib.refreshVendordeps",
-        "onCommand:extension.showWebsite"
+        "onCommand:wpilib.refreshVendordeps"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -419,12 +418,7 @@
                 "command": "wpilib.refreshVendordeps",
                 "title": "Refresh",
                 "icon": "$(refresh)"
-            },
-            {                
-                "command": "extension.showWebsite",
-                "title": "Show Website"
             }
-
         ],
         "views": {
             "explorer": [

--- a/vscode-wpilib/src/dependencyView.ts
+++ b/vscode-wpilib/src/dependencyView.ts
@@ -234,11 +234,7 @@ export class DependencyViewProvider implements vscode.WebviewViewProvider {
 
           if (success) {
             if (avail.instructions) {
-              await vscode.commands.executeCommand(
-                'extension.showWebsite',
-                avail.instructions,
-                dep.name
-              );
+              await vscode.commands.executeCommand('simpleBrowser.show', avail.instructions);
             }
             this.changed = Date.now();
 

--- a/vscode-wpilib/src/extension.ts
+++ b/vscode-wpilib/src/extension.ts
@@ -538,71 +538,10 @@ export async function activate(context: vscode.ExtensionContext) {
     gradle2025import,
     help
   );
-
-  // Register the command with arguments
-  let disposable = vscode.commands.registerCommand(
-    'extension.showWebsite',
-    (url: string, tabTitle: string) => {
-      // If no arguments were passed, you can prompt the user (optional):
-      if (!url) {
-        vscode.window.showErrorMessage('URL not provided!');
-        return;
-      }
-      if (!tabTitle) {
-        tabTitle = 'My Website'; // fallback title if not provided
-      }
-
-      // Create and show a new webview panel
-      const panel = vscode.window.createWebviewPanel(
-        'myWebview', // internal identifier
-        tabTitle, // use the dynamic title
-        vscode.ViewColumn.One,
-        {
-          enableScripts: true,
-          retainContextWhenHidden: true,
-        }
-      );
-
-      // Set the HTML content of the webview
-      panel.webview.html = getWebviewContent(url);
-    }
-  );
-
-  context.subscriptions.push(disposable);
-
   return externalApi;
 }
 
 // this method is called when your extension is deactivated
 export function deactivate() {
   closeLogger();
-}
-
-function getWebviewContent(url: string): string {
-  // Basic HTML that includes an iframe to your target website.
-  // NOTE: This will only work if the site allows iframes.
-  return `<!DOCTYPE html>
-  <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <style>
-      body, html {
-        padding: 0;
-        margin: 0;
-        height: 100%;
-        overflow: hidden;
-        background: #fff;
-      }
-      iframe {
-        border: none;
-        width: 100%;
-        height: 100%;
-      }
-    </style>
-  </head>
-  <body>
-    <iframe src="${url}" sandbox="allow-scripts allow-same-origin"></iframe>
-  </body>
-  </html>`;
 }


### PR DESCRIPTION
Using a custom webview feels out of place, and you can't save the URL if you want to go back later in a browser. Simple Browser, introduced in VS Code 1.53.0, is basically built for this exact purpose. There are a few small caveats, but they should be tolerable for our use case: clicking on the page will lock focus and the URL in the address bar will not update if the user navigates to a different page.
<img width="2560" height="1528" alt="image" src="https://github.com/user-attachments/assets/d0fdf4a8-ae5f-4c43-9793-18eaf5583f24" />
