### PR TITLE
Defer building code when vendor instructions shown

### DIFF
--- a/vscode-wpilib/src/dependencyView.ts
+++ b/vscode-wpilib/src/dependencyView.ts
@@ -47,6 +47,7 @@ export class DependencyViewProvider implements vscode.WebviewViewProvider {
   private vendordepMarketplaceURL = `https://frcmaven.wpi.edu/artifactory/vendordeps/vendordep-marketplace/`;
   private wp: vscode.WorkspaceFolder | undefined;
   private changed = 0;
+  private showingInstructions = false;
 
   private _view?: vscode.WebviewView;
 
@@ -92,7 +93,9 @@ export class DependencyViewProvider implements vscode.WebviewViewProvider {
         if (webviewView.visible) {
           void this._refresh(this.wp);
         } else {
-          if (this.changed > this.vendorLibraries.getLastBuild()) {
+          if (this.showingInstructions) {
+            this.showingInstructions = false;
+          } else if (this.changed > this.vendorLibraries.getLastBuild()) {
             this.externalApi.getBuildTestAPI().buildCode(this.wp, undefined);
             this.changed = 0;
           }
@@ -127,7 +130,9 @@ export class DependencyViewProvider implements vscode.WebviewViewProvider {
           }
           case 'blur': {
             if (this.wp) {
-              if (this.changed > this.vendorLibraries.getLastBuild()) {
+              if (this.showingInstructions) {
+                this.showingInstructions = false;
+              } else if (this.changed > this.vendorLibraries.getLastBuild()) {
                 this.externalApi.getBuildTestAPI().buildCode(this.wp, undefined);
                 this.changed = 0;
               }
@@ -234,6 +239,7 @@ export class DependencyViewProvider implements vscode.WebviewViewProvider {
 
           if (success) {
             if (avail.instructions) {
+              this.showingInstructions = true;
               await vscode.commands.executeCommand(
                 'extension.showWebsite',
                 avail.instructions,


### PR DESCRIPTION
Fixes #746
Loading the instructions leaves the dependency view visible, so code will still be built the next time the dependency view loses visibility