### PR TITLE
Change display name for WPILib extension settings

### DIFF
--- a/vscode-wpilib/package.json
+++ b/vscode-wpilib/package.json
@@ -109,7 +109,7 @@
         ],
         "configuration": {
             "type": "object",
-            "title": "WPILib configuration",
+            "title": "WPILib",
             "properties": {
                 "wpilib.additionalGradleArguments": {
                     "type": "string",


### PR DESCRIPTION
Other extensions use the extension name, while WPILib used "WPILib configuration", changed to just WPILib