### PR TITLE
Fix refresh button appearing on all panels

### DIFF
--- a/vscode-wpilib/package.json
+++ b/vscode-wpilib/package.json
@@ -525,6 +525,7 @@
             ],
             "view/title": [
                 {
+                    "when": "view.wpilib.dependencyView.visible",
                     "command": "wpilib.refreshVendordeps",
                     "group": "navigation"
                 }


### PR DESCRIPTION
Now it properly only appears on the Dependency View panel.