### PR TITLE
Bring back logging to VS Code's Output panel

### DIFF
--- a/vscode-wpilib/src/logger.ts
+++ b/vscode-wpilib/src/logger.ts
@@ -15,14 +15,14 @@ class VsCodeOutputTransport extends TransportStream {
     setImmediate(() => this.emit('logged', info));
     switch (info.level) {
       case 'error':
-        outputChannel.error(info.message, info.meta);
+        outputChannel.error(info.message, ...info.meta);
         break;
       case 'warn':
-        outputChannel.warn(info.message, info.meta);
+        outputChannel.warn(info.message, ...info.meta);
         break;
       // Log everything info and below as info
       default:
-        outputChannel.info(info.message, info.meta);
+        outputChannel.info(info.message, ...info.meta);
         break;
     }
     next();

--- a/vscode-wpilib/src/logger.ts
+++ b/vscode-wpilib/src/logger.ts
@@ -1,7 +1,33 @@
 'use strict';
 
 import * as path from 'path';
+import * as vscode from 'vscode';
 import * as winston from 'winston';
+import * as TransportStream from 'winston-transport';
+
+const outputChannel = vscode.window.createOutputChannel('WPILib', { log: true });
+class VsCodeOutputTransport extends TransportStream {
+  constructor(opts?: TransportStream.TransportStreamOptions) {
+    super(opts);
+  }
+
+  public log(info: winston.LogEntry, next: () => void) {
+    setImmediate(() => this.emit('logged', info));
+    switch (info.level) {
+      case 'error':
+        outputChannel.error(info.message, info.meta);
+        break;
+      case 'warn':
+        outputChannel.warn(info.message, info.meta);
+        break;
+      // Log everything info and below as info
+      default:
+        outputChannel.info(info.message, info.meta);
+        break;
+    }
+    next();
+  }
+}
 
 const myFormat = winston.format.printf((info) => {
   return `${info.timestamp} ${info.level}: ${info.message}`;
@@ -11,11 +37,12 @@ const winstonLogger = winston.createLogger({
   exitOnError: false,
   format: winston.format.combine(winston.format.timestamp(), winston.format.simple(), myFormat),
   level: 'verbose',
-  transports: [new winston.transports.Console()],
+  transports: [new VsCodeOutputTransport()],
 });
 
 export function closeLogger() {
   winstonLogger.close();
+  outputChannel.dispose();
 }
 
 let mainLogFile: string = '';


### PR DESCRIPTION
Removed in #680, but the console log is missing the `meta` objects that are logged, and that PR was only for the standalone utility. The Output panel is a far better place to log this.

Depends on #865 to fix the tests.

Some log errors for comparsion:
Old:
```
2026-06-01 21:55:56.753 [info] Found jdt.ls.java.home Version: 25 at C:\Program Files\Eclipse Adoptium\jdk-25.0.2.10-hotspot []
2026-06-01 21:55:56.753 [info] [Locale] Loading message@en []
2026-06-01 21:55:56.754 [error] [Locale] Failed to load message@en. [{"errno":-4058,"code":"ENOENT","syscall":"open","path":"c:\\Users\\gold295856\\.vscode\\extensions\\wpilibsuite.vscode-wpilib-0.1.0\\i18n\\en\\message.json"}]
2026-06-01 21:55:56.767 [info] no vendor examples found ["C:\\Users\\Public\\wpilib\\2026\\vendorexamples"]
2026-06-01 21:56:15.104 [info] Congratulations, your extension "vscode-wpilib" is now active! []
2026-06-01 21:56:22.399 [info] executing command in workspace [{"_args":[],"_commandLine":"gradlew clean  -Dorg.gradle.java.home=\"C:\\Program Files\\Eclipse Adoptium\\jdk-25.0.2.10-hotspot\"","_options":{"cwd":"d:\\PhoenixCIHang","env":{"JAVA_HOME":"C:\\Program Files\\Eclipse Adoptium\\jdk-25.0.2.10-hotspot"},"executable":"cmd.exe","shellArgs":["/d","/c"]}},"d:\\PhoenixCIHang"]
```

New:
```
2026-06-01 21:57:48.644 [info] Found jdt.ls.java.home Version: 25 at C:\Program Files\Eclipse Adoptium\jdk-25.0.2.10-hotspot
2026-06-01 21:57:48.645 [info] [Locale] Loading message@en
2026-06-01 21:57:48.645 [error] [Locale] Failed to load message@en. A system error occurred (ENOENT: no such file or directory, open 'c:\Users\gold295856\.vscode\extensions\wpilibsuite.vscode-wpilib-0.1.0\i18n\en\message.json')
2026-06-01 21:57:48.696 [info] no vendor examples found C:\Users\Public\wpilib\2026\vendorexamples
2026-06-01 21:57:49.648 [info] Congratulations, your extension "vscode-wpilib" is now active!
2026-06-01 21:57:53.248 [info] executing command in workspace {"_args":[],"_commandLine":"gradlew clean  -Dorg.gradle.java.home=\"C:\\Program Files\\Eclipse Adoptium\\jdk-25.0.2.10-hotspot\"","_options":{"cwd":"d:\\PhoenixCIHang","env":{"JAVA_HOME":"C:\\Program Files\\Eclipse Adoptium\\jdk-25.0.2.10-hotspot"},"executable":"cmd.exe","shellArgs":["/d","/c"]}} d:\PhoenixCIHang
```