### PR TITLE
Don't rely on file watcher for detecting wpilib prefs

### DIFF
--- a/libraries/vscode-wpilibapi/package.json
+++ b/libraries/vscode-wpilibapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-wpilibapi",
-  "version": "2021.1.1",
+  "version": "2026.1.2",
   "description": "Public API for vscode-wpilib",
   "typings": "./out/api.d.ts",
   "main": "./out/api.js",

--- a/libraries/vscode-wpilibapi/src/api.ts
+++ b/libraries/vscode-wpilibapi/src/api.ts
@@ -121,7 +121,7 @@ export interface IPreferences {
   setAutoStartRioLog(autoStart: boolean, global: boolean): Promise<void>;
   getAutoSaveOnDeploy(): boolean;
   setAutoSaveOnDeploy(autoSave: boolean, global: boolean): Promise<void>;
-  getIsWPILibProject(): boolean;
+  getIsWPILibProject(): Promise<boolean>;
   getEnableCppIntellisense(): boolean;
   setEnableCppIntellisense(set: boolean): Promise<void>;
   getProjectYear(): string;

--- a/vscode-wpilib/package-lock.json
+++ b/vscode-wpilib/package-lock.json
@@ -24,7 +24,7 @@
                 "vscode-cpptools": "^6.1.0",
                 "vscode-jsonrpc": "^8.1.0",
                 "vscode-nls": "^5.2.0",
-                "vscode-wpilibapi": "^2021.1.1",
+                "vscode-wpilibapi": "^2026.1.2",
                 "winston": "^3.3.3",
                 "winston-transport": "^4.4.0",
                 "xml2js": "^0.6.2"
@@ -10904,9 +10904,10 @@
             }
         },
         "node_modules/vscode-wpilibapi": {
-            "version": "2021.1.1",
-            "resolved": "https://registry.npmjs.org/vscode-wpilibapi/-/vscode-wpilibapi-2021.1.1.tgz",
-            "integrity": "sha512-kh8S9rDtZpUXoWjRYaJjNPP9oLPq8+czJ/uI1WINpk4otz6mNjpE2h5hRzBvFgUnJRZa8PMNdWD8Sl+NsoBLkw==",
+            "version": "2026.1.2",
+            "resolved": "file:../libraries/vscode-wpilibapi/vscode-wpilibapi-2026.1.2.tgz",
+            "integrity": "sha512-FZyTuZmvAHfUrzh1BHDq5BE6EgzQBXJ6WUWEd9S5kVnLufc4ZUZlgi8mtRrfN1qzBFD0sd2U7ccpBnBzre4z2Q==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "vscode": "^1.26.0"
             }
@@ -20229,9 +20230,8 @@
             }
         },
         "vscode-wpilibapi": {
-            "version": "2021.1.1",
-            "resolved": "https://registry.npmjs.org/vscode-wpilibapi/-/vscode-wpilibapi-2021.1.1.tgz",
-            "integrity": "sha512-kh8S9rDtZpUXoWjRYaJjNPP9oLPq8+czJ/uI1WINpk4otz6mNjpE2h5hRzBvFgUnJRZa8PMNdWD8Sl+NsoBLkw=="
+            "version": "2026.1.2",
+            "integrity": "sha512-FZyTuZmvAHfUrzh1BHDq5BE6EgzQBXJ6WUWEd9S5kVnLufc4ZUZlgi8mtRrfN1qzBFD0sd2U7ccpBnBzre4z2Q=="
         },
         "watchpack": {
             "version": "1.7.5",

--- a/vscode-wpilib/package.json
+++ b/vscode-wpilib/package.json
@@ -420,11 +420,10 @@
                 "title": "Refresh",
                 "icon": "$(refresh)"
             },
-            {                
+            {
                 "command": "extension.showWebsite",
                 "title": "Show Website"
             }
-
         ],
         "views": {
             "explorer": [
@@ -596,7 +595,7 @@
         "vscode-cpptools": "^6.1.0",
         "vscode-jsonrpc": "^8.1.0",
         "vscode-nls": "^5.2.0",
-        "vscode-wpilibapi": "^2021.1.1",
+        "vscode-wpilibapi": "^2026.1.2",
         "winston": "^3.3.3",
         "winston-transport": "^4.4.0",
         "xml2js": "^0.6.2"

--- a/vscode-wpilib/src/extension.ts
+++ b/vscode-wpilib/src/extension.ts
@@ -229,7 +229,7 @@ async function handleAfterTrusted(
   if (wp) {
     for (const w of wp) {
       const prefs = externalApi.getPreferencesAPI().getPreferences(w);
-      if (prefs.getIsWPILibProject()) {
+      if (await prefs.getIsWPILibProject()) {
         const vendorDepsPattern = new vscode.RelativePattern(
           path.join(w.uri.fsPath, 'vendordeps'),
           '**/*.json'

--- a/vscode-wpilib/src/java/java.ts
+++ b/vscode-wpilib/src/java/java.ts
@@ -57,7 +57,7 @@ export async function activateJava(context: vscode.ExtensionContext, coreExports
     if (wp) {
       for (const w of wp) {
         const prefs = coreExports.getPreferencesAPI().getPreferences(w);
-        if (prefs.getIsWPILibProject()) {
+        if (await prefs.getIsWPILibProject()) {
           const localW = w;
           const buildGradle = path.join(localW.uri.fsPath, 'build.gradle');
           if (await existsAsync(buildGradle)) {

--- a/vscode-wpilib/src/preferences.ts
+++ b/vscode-wpilib/src/preferences.ts
@@ -84,7 +84,16 @@ export class Preferences implements IPreferences {
     });
   }
 
-  public getIsWPILibProject(): boolean {
+  public async getIsWPILibProject(): Promise<boolean> {
+    if (!this.isWPILibProject) {
+      const configFilePath = Preferences.getPrefrencesFilePath(this.workspace.uri.fsPath);
+      if (await existsAsync(configFilePath)) {
+        await vscode.commands.executeCommand('setContext', 'isWPILibProject', true);
+        this.isWPILibProject = true;
+        this.preferencesFile = vscode.Uri.file(configFilePath);
+        await this.updatePreferences();
+      }
+    }
     return this.isWPILibProject;
   }
 

--- a/vscode-wpilib/src/projectinfo.ts
+++ b/vscode-wpilib/src/projectinfo.ts
@@ -58,13 +58,19 @@ export class ProjectInfoGatherer {
 
     const workspaces = vscode.workspace.workspaceFolders;
     if (workspaces !== undefined) {
-      for (const wp of workspaces) {
-        const prefs = this.externalApi.getPreferencesAPI().getPreferences(wp);
-        if (prefs.getIsWPILibProject()) {
-          this.statusBar.show();
-          break;
+      // Constructor cannot be async, so run an async check to show the status bar.
+      // Capture locals to avoid using `this` in an async IIFE (prevents TS "used before assigned" checks).
+      const externalApiLocal = this.externalApi;
+      const statusBarLocal = this.statusBar;
+      (async () => {
+        for (const wp of workspaces) {
+          const prefs = externalApiLocal.getPreferencesAPI().getPreferences(wp);
+          if (await prefs.getIsWPILibProject()) {
+            statusBarLocal.show();
+            break;
+          }
         }
-      }
+      })();
     }
 
     this.disposables.push(

--- a/vscode-wpilib/src/vscommands.ts
+++ b/vscode-wpilib/src/vscommands.ts
@@ -77,7 +77,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot set team number since this is not a WPILib project')
@@ -107,7 +107,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
         const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
         if (
           workspace === undefined ||
-          !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+          !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
         ) {
           vscode.window.showInformationMessage(
             i18n('message', 'Cannot deploy code since this is not a WPILib project')
@@ -127,7 +127,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
         const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
         if (
           workspace === undefined ||
-          !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+          !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
         ) {
           vscode.window.showInformationMessage(
             i18n('message', 'Cannot debug code since this is not a WPILib project')
@@ -147,7 +147,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
         const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
         if (
           workspace === undefined ||
-          !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+          !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
         ) {
           vscode.window.showInformationMessage(
             i18n('message', 'Cannot simulate code since this is not a WPILib project')
@@ -167,7 +167,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
         const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
         if (
           workspace === undefined ||
-          !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+          !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
         ) {
           vscode.window.showInformationMessage(
             i18n('message', 'Cannot simulate code since this is not a WPILib project')
@@ -187,7 +187,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
         const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
         if (
           workspace === undefined ||
-          !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+          !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
         ) {
           vscode.window.showInformationMessage(
             i18n('message', 'Cannot start tests since this is not a WPILib project')
@@ -207,7 +207,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
         const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
         if (
           workspace === undefined ||
-          !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+          !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
         ) {
           vscode.window.showInformationMessage(
             i18n('message', 'Cannot build robot code since this is not a WPILib project')
@@ -233,7 +233,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
         const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
         if (
           workspace === undefined ||
-          !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+          !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
         ) {
           vscode.window.showInformationMessage(
             i18n('message', 'Cannot create command since this is not a WPILib project')
@@ -251,7 +251,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot set language since this is not a WPILib project')
@@ -289,7 +289,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot set skip tests since this is not a WPILib project')
@@ -317,7 +317,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n(
@@ -352,7 +352,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n(
@@ -387,7 +387,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot set offline since this is not a WPILib project')
@@ -419,7 +419,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot set deploy offline since this is not a WPILib project')
@@ -451,7 +451,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot set stop simulation since this is not a WPILib project')
@@ -483,7 +483,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot set windbgx since this is not a WPILib project')
@@ -519,7 +519,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot set auto save since this is not a WPILib project')
@@ -551,7 +551,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot set start RioLog since this is not a WPILib project')
@@ -602,7 +602,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot install gradle tools since this is not a WPILib project')
@@ -625,7 +625,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const wp = await externalApi.getPreferencesAPI().getFirstOrSelectedWorkspace();
       if (
         wp === undefined ||
-        !externalApi.getPreferencesAPI().getPreferences(wp).getIsWPILibProject()
+        !(await externalApi.getPreferencesAPI().getPreferences(wp).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot run gradle command since this is not a WPILib project')
@@ -655,7 +655,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const workspace = await preferencesApi.getFirstOrSelectedWorkspace();
       if (
         workspace === undefined ||
-        !preferencesApi.getPreferences(workspace).getIsWPILibProject()
+        !(await preferencesApi.getPreferences(workspace).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot reset auto update since this is not a WPILib project')
@@ -771,7 +771,7 @@ export function createVsCommands(context: vscode.ExtensionContext, externalApi: 
       const wp = await externalApi.getPreferencesAPI().getFirstOrSelectedWorkspace();
       if (
         wp === undefined ||
-        !externalApi.getPreferencesAPI().getPreferences(wp).getIsWPILibProject()
+        !(await externalApi.getPreferencesAPI().getPreferences(wp).getIsWPILibProject())
       ) {
         vscode.window.showInformationMessage(
           i18n('message', 'Cannot run gradle clean since this is not a WPILib project')


### PR DESCRIPTION
double check the existence of the wpilib prefs file if file watcher thinks it doesn't exist
One possible fix for #836
Requires publishing a new version of vscode-wpilibapi