### PR TITLE
Double check if wpilib prefs file is deleted

### DIFF
--- a/vscode-wpilib/src/preferences.ts
+++ b/vscode-wpilib/src/preferences.ts
@@ -73,9 +73,16 @@ export class Preferences implements IPreferences {
     });
 
     this.configFileWatcher.onDidDelete(async () => {
-      await vscode.commands.executeCommand('setContext', 'isWPILibProject', false);
-      this.isWPILibProject = false;
-      this.preferencesFile = undefined;
+      const configFilePath = Preferences.getPrefrencesFilePath(this.workspace.uri.fsPath);
+      if (await existsAsync(configFilePath)) {
+        await vscode.commands.executeCommand('setContext', 'isWPILibProject', true);
+        this.isWPILibProject = true;
+        this.preferencesFile = vscode.Uri.file(configFilePath);
+      } else {
+        await vscode.commands.executeCommand('setContext', 'isWPILibProject', false);
+        this.isWPILibProject = false;
+        this.preferencesFile = undefined;
+      }
       await this.updatePreferences();
     });
 


### PR DESCRIPTION
This is a much less invasive way to address #836 compared to #37, although likely less robust. In the file watcher on delete method, check if the file exists.
I was able to get this code to trigger a few times and it did work, but probably isn't 100% reliable if the file isn't recreated before the second check is immediately executed.
Fixes #836