### PR TITLE
Don't rely on file watcher for detecting wpilib prefs

### DIFF
--- a/vscode-wpilib/src/preferences.ts
+++ b/vscode-wpilib/src/preferences.ts
@@ -102,11 +102,11 @@ export class Preferences implements IPreferences {
         this.isWPILibProject = true;
         this.preferencesFile = vscode.Uri.file(configFilePath);
         this.updatePreferences().catch((err) => {
-          logger.error("Failed to update WPILib preferences", err);
+          logger.error('Failed to update WPILib preferences', err);
         });
       }
     } catch (err) {
-      logger.error("Failed to update WPILib preferences", err);
+      logger.error('Failed to update WPILib preferences', err);
     }
 
     return this.isWPILibProject;


### PR DESCRIPTION
double check the existence of the wpilib prefs file if file watcher thinks it doesn't exist Uses synchronous file APIs so it's less invasive then #837. Updating the prefs file synchronously should be very rare.