### PR TITLE
Change the language in project import error to be more descriptive

### DIFF
--- a/vscode-wpilib/src/webviews/gradle2020import.ts
+++ b/vscode-wpilib/src/webviews/gradle2020import.ts
@@ -199,7 +199,7 @@ export class Gradle2020Import extends WebViewBase {
         await vscode.window.showErrorMessage(
           i18n(
             'message',
-            'Failed to detect project type. Did you select the build.gradle file of a wpilib project?'
+            'Failed to detect project language. Check the .wpilib/wpilib_preferences.json file and be sure that the currentLanguage field is set to either "java" or "cpp".'
           ),
           {
             modal: true,


### PR DESCRIPTION
Upon attempting to convert our Phoenix Tuner generated Swerve codebase to WPILib 2026 during Kickoff, I encountered this error that threw me for a loop, only figuring out the root cause by diving into the source code and finding what was causing the error in the first place.

This PR should make it easier for any other teams, who have misconfigured WPILib projects, to properly diagnose the error quickly.