### PR TITLE
Fix project creation on read-only filesystems (NixOS)

### DIFF
--- a/vscode-wpilib/src/shared/permissions.ts
+++ b/vscode-wpilib/src/shared/permissions.ts
@@ -1,6 +1,28 @@
 'use strict';
 
 import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Recursively ensures all files and directories under `dir` are
+ * owner-writable. This is needed when copying from read-only
+ * filesystems (e.g. the Nix store) where copied files preserve
+ * the source's read-only permissions.
+ */
+export async function setWritableRecursive(dir: string): Promise<void> {
+  if (process.platform === 'win32') {
+    return;
+  }
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await setWritableRecursive(fullPath);
+    }
+    const stat = await fs.promises.stat(fullPath);
+    await fs.promises.chmod(fullPath, stat.mode | fs.constants.S_IWUSR);
+  }
+}
 
 export function setExecutePermissions(file: string): Promise<void> {
   if (process.platform === 'win32') {

--- a/vscode-wpilib/src/utilities.ts
+++ b/vscode-wpilib/src/utilities.ts
@@ -7,7 +7,7 @@ import * as util from 'util';
 import * as vscode from 'vscode';
 import { IExecuteAPI, IPreferences } from 'vscode-wpilibapi';
 import { localize as i18n } from './locale';
-import { setExecutePermissions } from './shared/permissions';
+import { setExecutePermissions, setWritableRecursive } from './shared/permissions';
 
 // General utilites usable by multiple classes
 
@@ -69,18 +69,25 @@ export const deleteFileAsync = util.promisify(fs.unlink);
 
 export const mkdirpAsync = mkdirp;
 
-export function ncpAsync(source: string, dest: string, options: ncp.Options = {}): Promise<void> {
-  return mkdirpAsync(dest).then(() => {
-    return new Promise<void>((resolve, reject) => {
-      ncp.ncp(source, dest, options, (err) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve();
-        }
-      });
+export async function ncpAsync(
+  source: string,
+  dest: string,
+  options: ncp.Options = {}
+): Promise<void> {
+  await mkdirpAsync(dest);
+  await new Promise<void>((resolve, reject) => {
+    ncp.ncp(source, dest, options, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
     });
   });
+  // Ensure copied files are writable. This is necessary when the source
+  // resides on a read-only filesystem (e.g. the Nix store on NixOS),
+  // because ncp preserves the source's file permissions.
+  await setWritableRecursive(dest);
 }
 
 export const readdirAsync = util.promisify(fs.readdir);


### PR DESCRIPTION
When the `vscode-wpilib` extension is installed via a read-only filesystem (e.g. the Nix store on NixOS), project creation fails with "Cannot create into non empty folder" because `ncp` preserves source file permissions when copying templates but files in the Nix store are read-only (`0444`). The copied project files inherit read-only permissions and then subsequent steps (e.g. replacing `###GRADLERIOREPLACE###` in `build.gradle`) fail because `fs.writeFile` cannot write to read-only files.

### Changes

- **`permissions.ts`**: Add `setWritableRecursive()` helper that recursively ensures owner-write permission on all files/directories (no-op on Windows)
- **`utilities.ts`**: Call `setWritableRecursive(dest)` after each `ncp` copy in `ncpAsync` to ensure copied files are always writable

This is a no-op on normal systems where files are already writable, and fixes project creation on NixOS and any other environment where the extension is installed on a read-only filesystem.