### PR TITLE
locale.ts: Don't print error for missing `en` locale either

### DIFF
--- a/vscode-wpilib/src/locale.ts
+++ b/vscode-wpilib/src/locale.ts
@@ -96,7 +96,7 @@ export function loadLocaleFile(domain: string) {
     logger.log(`[Locale] Loaded ${domain}@${options.language}`);
   } catch (e) {
     localeCache[domain] = {}; // suppress errors when finding messages in non-existence domain
-    if (domain !== 'en-us') {
+    if (domain !== 'en-us' && domain !== 'en') {
       logger.error(`[Locale] Failed to load ${domain}@${options.language}.`, e);
     }
   }


### PR DESCRIPTION
Found when debugging running the extension on llcodeserver (openvscode-server)

See-also: https://github.com/wpilibsuite/vscode-wpilib/pull/500