### PR TITLE
Port Java simulation cancelling to C++

### DIFF
--- a/vscode-wpilib/src/cpp/deploydebug.ts
+++ b/vscode-wpilib/src/cpp/deploydebug.ts
@@ -339,13 +339,14 @@ class SimulateCodeDeployer implements ICodeDeployer {
           canPickMany: true,
           placeHolder: 'Pick extensions to run',
         });
-        if (quickPick !== undefined) {
-          for (const qp of quickPick) {
-            extensions += qp.path;
-            extensions += path.delimiter;
-          }
+        if (quickPick === undefined) {
+          vscode.window.showInformationMessage('Simulation cancelled');
+          return false;
         }
-      }
+        for (const qp of quickPick) {
+          extensions += qp.path;
+          extensions += path.delimiter;
+        }
     }
 
     if (!getIsWindows()) {


### PR DESCRIPTION
https://github.com/wpilibsuite/vscode-wpilib/commit/6c5bc8b61e8b2ed03e56e8cdb5d8c6ff63d2a864 only fixed this behavior on Java