### PR TITLE
Move wpilibHome to the top of the plugin repository list

### DIFF
--- a/vscode-wpilib/resources/gradle/shared/settings.gradle
+++ b/vscode-wpilib/resources/gradle/shared/settings.gradle
@@ -2,8 +2,6 @@ import org.gradle.internal.os.OperatingSystem
 
 pluginManagement {
     repositories {
-        mavenLocal()
-        gradlePluginPortal()
         String wpilibYear = '2027_alpha5'
         File wpilibHome
         if (OperatingSystem.current().isWindows()) {
@@ -23,6 +21,8 @@ pluginManagement {
             name = 'wpilibHome'
             url = wpilibHomeMaven
         }
+        mavenLocal()
+        gradlePluginPortal()
     }
 }
 


### PR DESCRIPTION
This fixes offline builds as Gradle will [stop checking the next repos in the list if it encounters errors in a repo](https://docs.gradle.org/current/userguide/graph_resolution.html#sec:repository-disabling).