### PR TITLE
Disable Run/Debug Java CodeLens provider

### DIFF
--- a/vscode-wpilib/resources/gradle/java/.vscode/settings.json
+++ b/vscode-wpilib/resources/gradle/java/.vscode/settings.json
@@ -57,5 +57,6 @@
     "org.wpilib.math.**.proto.*",
     "org.wpilib.math.**.struct.*",
   ],
+  "java.debug.settings.enableRunDebugCodeLens": false,
   "java.dependency.enableDependencyCheckup": false
 }

--- a/vscode-wpilib/resources/gradle/javadt/.vscode/settings.json
+++ b/vscode-wpilib/resources/gradle/javadt/.vscode/settings.json
@@ -39,5 +39,6 @@
     "org.mockito.Answers.*",
     "org.wpilib.units.Units.*"
   ],
+  "java.debug.settings.enableRunDebugCodeLens": false,
   "java.dependency.enableDependencyCheckup": false
 }

--- a/vscode-wpilib/resources/gradle/javaromi/.vscode/settings.json
+++ b/vscode-wpilib/resources/gradle/javaromi/.vscode/settings.json
@@ -58,5 +58,6 @@
     "org.wpilib.math.**.proto.*",
     "org.wpilib.math.**.struct.*",
   ],
+  "java.debug.settings.enableRunDebugCodeLens": false,
   "java.dependency.enableDependencyCheckup": false
 }

--- a/vscode-wpilib/resources/gradle/javaxrp/.vscode/settings.json
+++ b/vscode-wpilib/resources/gradle/javaxrp/.vscode/settings.json
@@ -58,5 +58,6 @@
     "org.wpilib.math.**.proto.*",
     "org.wpilib.math.**.struct.*",
   ],
+  "java.debug.settings.enableRunDebugCodeLens": false,
   "java.dependency.enableDependencyCheckup": false
 }


### PR DESCRIPTION
This will not set up JNI dependencies correctly, and worse, it will actually leave a config behind in launch.json, causing sim to fail (if launched from Main.java) until it's removed. Disable this on all projects to prevent that.