### PR TITLE
Don't use callbacks to read template/example files

### DIFF
--- a/vscode-wpilib/src/cpp/commands.ts
+++ b/vscode-wpilib/src/cpp/commands.ts
@@ -1,6 +1,5 @@
 'use strict';
-import * as fs from 'fs';
-import { copyFile } from 'fs/promises';
+import { copyFile, readFile } from 'fs/promises';
 import * as jsonc from 'jsonc-parser';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -63,18 +62,15 @@ async function performCopy(
 
 const commandResourceName = 'commands.json';
 
-export function registerCommandTemplates(
+export async function registerCommandTemplates(
   resourceRoot: string,
   core: ICommandAPI,
   preferences: IPreferencesAPI
 ) {
   const commandFolder = path.join(resourceRoot, 'src', 'commands');
   const resourceFile = path.join(commandFolder, commandResourceName);
-  fs.readFile(resourceFile, 'utf8', (err, data) => {
-    if (err) {
-      logger.log('Command error: ', err);
-      return;
-    }
+  try {
+    const data = await readFile(resourceFile, 'utf8');
     const commands: ICppJsonLayout[] = jsonc.parse(data) as ICppJsonLayout[];
     for (const c of commands) {
       const provider: ICommandCreator = {
@@ -147,5 +143,7 @@ export function registerCommandTemplates(
       };
       core.addCommandProvider(provider);
     }
-  });
+  } catch (err) {
+    logger.log('Command error: ', err);
+  }
 }

--- a/vscode-wpilib/src/cpp/cpp.ts
+++ b/vscode-wpilib/src/cpp/cpp.ts
@@ -41,9 +41,9 @@ export async function activateCpp(context: vscode.ExtensionContext, coreExports:
   registerCodeDeployerAndDebugger(coreExports, allowDebug);
 
   // Setup commands
-  registerCommandTemplates(extensionResourceLocation, commandApi, preferences);
+  await registerCommandTemplates(extensionResourceLocation, commandApi, preferences);
 
   // Setup examples and template
-  registerExamples(extensionResourceLocation, false, exampleTemplate);
-  registerProjectTemplates(extensionResourceLocation, false, exampleTemplate);
+  await registerExamples(extensionResourceLocation, false, exampleTemplate);
+  await registerProjectTemplates(extensionResourceLocation, false, exampleTemplate);
 }

--- a/vscode-wpilib/src/java/commands.ts
+++ b/vscode-wpilib/src/java/commands.ts
@@ -1,6 +1,5 @@
 'use strict';
-import { readFile } from 'fs';
-import { copyFile } from 'fs/promises';
+import { copyFile, readFile } from 'fs/promises';
 import * as jsonc from 'jsonc-parser';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -55,18 +54,15 @@ async function performCopy(
 
 const commandResourceName = 'commands.json';
 
-export function registerCommandTemplates(
+export async function registerCommandTemplates(
   resourceRoot: string,
   core: ICommandAPI,
   preferences: IPreferencesAPI
 ) {
   const commandFolder = path.join(resourceRoot, 'src', 'commands');
   const resourceFile = path.join(commandFolder, commandResourceName);
-  readFile(resourceFile, 'utf8', (err, data) => {
-    if (err) {
-      logger.error('Command file error: ', err);
-      return;
-    }
+  try {
+    const data = await readFile(resourceFile, 'utf8');
     const commands: IJavaJsonLayout[] = jsonc.parse(data) as IJavaJsonLayout[];
     for (const c of commands) {
       const provider: ICommandCreator = {
@@ -117,5 +113,7 @@ export function registerCommandTemplates(
       };
       core.addCommandProvider(provider);
     }
-  });
+  } catch (err) {
+    logger.error('Command file error: ', err);
+  }
 }

--- a/vscode-wpilib/src/java/java.ts
+++ b/vscode-wpilib/src/java/java.ts
@@ -40,11 +40,11 @@ export async function activateJava(context: vscode.ExtensionContext, coreExports
   registerCodeDeployerAndDebugger(coreExports, allowDebug);
 
   // Setup commands
-  registerCommandTemplates(extensionResourceLocation, commandApi, preferences);
+  await registerCommandTemplates(extensionResourceLocation, commandApi, preferences);
 
   // Setup examples and template
-  registerExamples(extensionResourceLocation, true, exampleTemplate);
-  registerProjectTemplates(extensionResourceLocation, true, exampleTemplate);
+  await registerExamples(extensionResourceLocation, true, exampleTemplate);
+  await registerProjectTemplates(extensionResourceLocation, true, exampleTemplate);
 
   if (vscode.extensions.getExtension('redhat.java')) {
     // Add handlers for each workspace if java is installed

--- a/vscode-wpilib/src/shared/examples.ts
+++ b/vscode-wpilib/src/shared/examples.ts
@@ -1,5 +1,5 @@
 'use strict';
-import * as fs from 'fs';
+import { readFile } from 'fs/promises';
 import * as jsonc from 'jsonc-parser';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -22,16 +22,17 @@ export interface IExampleJsonLayout {
 
 const exampleResourceName = 'examples.json';
 
-export function registerExamples(resourceRoot: string, java: boolean, core: IExampleTemplateAPI) {
+export async function registerExamples(
+  resourceRoot: string,
+  java: boolean,
+  core: IExampleTemplateAPI
+) {
   const examplesFolder = path.join(resourceRoot, 'src', 'examples');
   const examplesTestFolder = path.join(resourceRoot, 'src', 'examples_test');
   const resourceFile = path.join(examplesFolder, exampleResourceName);
   const gradleBasePath = path.join(path.dirname(resourceRoot), 'gradle');
-  fs.readFile(resourceFile, 'utf8', (err, data) => {
-    if (err) {
-      logger.log('Example Error error: ', err);
-      return;
-    }
+  try {
+    const data = await readFile(resourceFile, 'utf8');
     const examples: IExampleJsonLayout[] = jsonc.parse(data) as IExampleJsonLayout[];
     for (const e of examples) {
       const vendordeps: string[] = e.extravendordeps ?? [];
@@ -105,5 +106,7 @@ export function registerExamples(resourceRoot: string, java: boolean, core: IExa
       };
       core.addExampleProvider(provider);
     }
-  });
+  } catch (err) {
+    logger.log('Example error: ', err);
+  }
 }

--- a/vscode-wpilib/src/shared/templates.ts
+++ b/vscode-wpilib/src/shared/templates.ts
@@ -1,5 +1,5 @@
 'use strict';
-import * as fs from 'fs';
+import { readFile } from 'fs/promises';
 import * as jsonc from 'jsonc-parser';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -22,7 +22,7 @@ export interface ITemplateJsonLayout {
 
 const exampleResourceName = 'templates.json';
 
-export function registerProjectTemplates(
+export async function registerProjectTemplates(
   resourceRoot: string,
   java: boolean,
   core: IExampleTemplateAPI
@@ -31,11 +31,8 @@ export function registerProjectTemplates(
   const templatesTestFolder = path.join(resourceRoot, 'src', 'templates_test');
   const resourceFile = path.join(templatesFolder, exampleResourceName);
   const gradleBasePath = path.join(path.dirname(resourceRoot), 'gradle');
-  fs.readFile(resourceFile, 'utf8', (err, data) => {
-    if (err) {
-      logger.log('Template error: ', err);
-      return;
-    }
+  try {
+    const data = await readFile(resourceFile, 'utf8');
     const templates: ITemplateJsonLayout[] = jsonc.parse(data) as ITemplateJsonLayout[];
     for (const e of templates) {
       const vendordeps: string[] = e.extravendordeps ?? [];
@@ -109,5 +106,7 @@ export function registerProjectTemplates(
       };
       core.addTemplateProvider(provider);
     }
-  });
+  } catch (err) {
+    logger.log('Template error: ', err);
+  }
 }


### PR DESCRIPTION
When the extension is just initialized and project generation is immediately attempted, the non-blocking nature of the callback means that it may not have enough time to read the file, thus causing project generation to fail since the templates/examples aren't loaded.

This unblocks #865 (and for those following the chain at home, required #868 to be merged).