### PR TITLE
Use longer test timeout

### DIFF
--- a/vscode-wpilib/.vscode-test.mjs
+++ b/vscode-wpilib/.vscode-test.mjs
@@ -1,3 +1,9 @@
 import { defineConfig } from '@vscode/test-cli';
 
-export default defineConfig({ files: 'out/test/**/*.js', version: '1.116.0' });
+export default defineConfig({
+  files: 'out/test/**/*.js',
+  version: '1.116.0',
+  mocha: {
+    timeout: 10000,
+  },
+});


### PR DESCRIPTION
Should fix an issue with Mac tests timing out after 2 seconds.