### PR TITLE
Reload Java project config on build

### DIFF
--- a/vscode-wpilib/src/java/buildtest.ts
+++ b/vscode-wpilib/src/java/buildtest.ts
@@ -35,6 +35,7 @@ class CodeBuilder implements ICodeBuilder {
       this.executeApi,
       prefs
     );
+    vscode.commands.executeCommand('java.projectConfiguration.update');
     logger.log(result.toString());
     return true;
   }
@@ -78,7 +79,7 @@ class CodeTester implements ICodeBuilder {
       this.executeApi,
       prefs
     );
-
+    vscode.commands.executeCommand('java.projectConfiguration.update');
     logger.log(result.toString());
     return true;
   }


### PR DESCRIPTION
Testing shows this significantly reduces the rate of (or completely eliminates) Intellisense errors due to generated code from annotation processors.